### PR TITLE
databaseのprimary記述を削除

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -78,9 +78,8 @@ test:
 # for a full overview on how database connection configuration can be specified.
 #
 production:
-  primary: &primary_production
-    <<: *default
-    host: <%= ENV["DB_HOST"] %>
-    database: <%= ENV["POSTGRES_DB"] %>
-    username: <%= ENV["POSTGRES_USER"] %>
-    password: <%= ENV["POSTGRES_PASSWORD"] %>
+  <<: *default
+  host: <%= ENV["DB_HOST"] %>
+  database: <%= ENV["POSTGRES_DB"] %>
+  username: <%= ENV["POSTGRES_USER"] %>
+  password: <%= ENV["POSTGRES_PASSWORD"] %>


### PR DESCRIPTION
## 概要
単一dbを使っていることを明確にするためにdatabase.ymlの設定の記載方法を変更した