### PR TITLE
deploy.ymlにdiscordログイン用の設定を追加

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -60,6 +60,8 @@ env:
     - POSTGRES_PASSWORD
     - DISCORD_CLIENT_ID
     - DISCORD_CLIENT_SECRET
+    - DISCORD_BOT_TOKEN
+    - DISCORD_SERVER_ID
     - DISCORD_REDIRECT_URI
 
 # Aliases are triggered with "bin/kamal <alias>". You can overwrite arguments on invocation:


### PR DESCRIPTION
## Issue
- #14 
## 概要
deploy.ymlにdiscordログイン用のbot_tokenとserver_idの記述を追加