### PR TITLE
embedのimageとthumbnailの切り替えを追加

### DIFF
--- a/app/models/discord_webhook.rb
+++ b/app/models/discord_webhook.rb
@@ -8,31 +8,31 @@ class DiscordWebhook
   end
 
   def notify_item_published(item)
-    send_webhook("🛒新しい商品が出品されました！", item)
+    send_webhook("🛒新しい商品が出品されました！", item, use_image: true)
   end
 
   def notify_item_closed(users, item)
-    send_webhook("#{create_mentions(users)}\n📢出品が取り下げられました", item)
+    send_webhook("#{create_mentions(users)}\n📢出品が取り下げられました", item, use_image: false)
   end
 
   def notify_item_deadline_extended(users, item)
-    send_webhook("#{create_mentions(users)}\n⏰購入希望申込期限が延長されました", item)
+    send_webhook("#{create_mentions(users)}\n⏰購入希望申込期限が延長されました", item, use_image: false)
   end
 
   def notify_lottery_completed(users, item)
-    send_webhook("#{create_mentions(users)}\n🎉抽選が完了し#{item.winner.name}さんが当選しました！", item)
+    send_webhook("#{create_mentions(users)}\n🎉抽選が完了し#{item.winner.name}さんが当選しました！", item, use_image: false)
   end
 
   def notify_lottery_skipped(users, item)
-    send_webhook("#{create_mentions(users)}\n⏭️希望者がいなかったため当選者なしで公開終了しました", item)
+    send_webhook("#{create_mentions(users)}\n⏭️希望者がいなかったため当選者なしで公開終了しました", item, use_image: false)
   end
 
   def notify_new_comment(users, item)
-    send_webhook("#{create_mentions(users)}\n📝新しいコメントがつきました", item)
+    send_webhook("#{create_mentions(users)}\n📝新しいコメントがつきました", item, use_image: false)
   end
 
   def notify_new_message(users, item)
-    send_webhook("#{create_mentions(users)}\n💬新しいメッセージが届きました", item)
+    send_webhook("#{create_mentions(users)}\n💬新しいメッセージが届きました", item, use_image: false)
   end
 
   private
@@ -41,14 +41,14 @@ class DiscordWebhook
     Array.wrap(users).map { |user| "<@#{user.uid}>" }.join(" ")
   end
 
-  def send_webhook(content, item)
+  def send_webhook(content, item, use_image: false)
     @client.execute do |builder|
       builder.content = content
-      builder.add_embed { |embed| build_item_embed(embed, item) }
+      builder.add_embed { |embed| build_item_embed(embed, item, use_image: use_image) }
     end
   end
 
-  def build_item_embed(embed, item)
+  def build_item_embed(embed, item, use_image: false)
     embed.title = item.title
     embed.url = item_url(item)
     embed.description = item.description
@@ -56,7 +56,16 @@ class DiscordWebhook
     embed.add_field(name: "送料負担", value: "#{I18n.t("enums.item.shipping_fee_payer.#{item.shipping_fee_payer}")}", inline: true)
     embed.add_field(name: "お支払い方法", value: "#{item.payment_method}", inline: true)
     embed.add_field(name: "購入希望申込期限", value: "#{I18n.l(item.entry_deadline_at, format: :default)}", inline: false)
-    embed.image = Discordrb::Webhooks::EmbedImage.new(url: "#{url_for(item.images.first)}")
+
+    image_url = url_for(item.images.first)
+    if use_image
+      embed.image = Discordrb::Webhooks::EmbedImage.new(url: image_url)
+      embed.thumbnail = nil
+    else
+      embed.thumbnail = Discordrb::Webhooks::EmbedThumbnail.new(url: image_url)
+      embed.image = nil
+    end
+
     embed.footer = Discordrb::Webhooks::EmbedFooter.new(text: "出品者: #{item.user.name}", icon_url: "#{item.user.avatar_url.presence || "default-avatar.png"}")
   end
 end


### PR DESCRIPTION
## Issue
- #165 
## 概要
discord通知の画像を、出品時は大きいimage、それ以外の通知は小さいthumbnailを使うように変更した