### PR TITLE
adminの場合取引相手がnilになる問題の修正

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -44,7 +44,9 @@ class Item < ApplicationRecord
   }
 
   def other_user_for(current_user)
-    return nil if current_user.admin?
+    if current_user.admin?
+      return nil unless [ user, winner ].include?(current_user)
+    end
 
     [ user, winner ].find { |user| user != current_user }
   end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -189,6 +189,24 @@ RSpec.describe Item, discord_stub: false, type: :model do
         expect(item.other_user_for(buyer)).to eq(seller)
       end
     end
+
+    context "when current user is admin and not involved" do
+      it "returns nil" do
+        admin = create(:user, :admin)
+        create(:entry, :won, item: item, user: buyer)
+
+        expect(item.other_user_for(admin)).to be_nil
+      end
+    end
+
+    context "when current user is admin and is seller" do
+      it "returns buyer" do
+        admin = seller
+        create(:entry, :won, item: item, user: buyer)
+
+        expect(item.other_user_for(admin)).to eq(buyer)
+      end
+    end
   end
 
   describe "#close!" do


### PR DESCRIPTION
## Issue
- #193 
## 概要
adminログインだと取引相手がnilになるコードを修正してadminが取引に参加していても取引相手の名前が表示されるようにした