### PR TITLE
通知系をActiveSupport::Notificationsで管理

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -70,7 +70,7 @@ class ItemsController < ApplicationController
     end
 
     if params[:close]
-      @item.close!(by: :user)
+      @item.close(reason: :user_action)
       redirect_to listings_path, notice: "商品を取り下げました", status: :see_other
       return
     end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -17,10 +17,6 @@ class Comment < ApplicationRecord
   end
 
   def notify_watchers
-    DiscordWebhook.new.notify_new_comment(item.watchers.without(self.user), item)
-    item.watchers.each do |watcher|
-      next if self.user_id == watcher.id
-      Notification.create!(user: watcher, notifiable: self)
-    end
+    ActiveSupport::Notifications.instrument("comment.created", comment: self)
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -51,9 +51,9 @@ class Item < ApplicationRecord
     [ user, winner ].find { |user| user != current_user }
   end
 
-  def close!(by:)
+  def close(reason: :user_action)
     update!(status: :closed)
-    notify_close(by)
+    ActiveSupport::Notifications.instrument("item.closed", item: self, reason: reason)
     entries.destroy_all
   end
 
@@ -116,29 +116,16 @@ class Item < ApplicationRecord
   end
 
   def notify_publishing
-    DiscordWebhook.new.notify_item_published(self)
+    ActiveSupport::Notifications.instrument("item.published", item: self)
   end
 
   def notify_deadline_extension
-    DiscordWebhook.new.notify_item_deadline_extended(applicants, self)
+    ActiveSupport::Notifications.instrument("item.deadline_extended", item: self)
   end
 
   def saved_only_change_deadline?
     return false if saved_change_to_attribute?(:status)
 
     saved_change_to_attribute?(:entry_deadline_at)
-  end
-
-  def notify_close(closed_by)
-    case closed_by
-    when :user
-      applicants.each do |applicant|
-        Notification.create!(user: applicant, notifiable: self)
-      end
-      DiscordWebhook.new.notify_item_closed(applicants, self)
-    when :lottery
-      Notification.create!(user: user, notifiable: self)
-      DiscordWebhook.new.notify_lottery_skipped(self.user, self)
-    end
   end
 end

--- a/app/models/lottery.rb
+++ b/app/models/lottery.rb
@@ -11,13 +11,9 @@ class Lottery
       losers.update_all(status: :lost)
       winner.update!(status: :won)
       @item.update!(status: :sold)
-      entries.each do |entry|
-        Notification.create!(user: entry.user, notifiable: entry)
-      end
-      Notification.create!(user: @item.user, notifiable: @item)
-      DiscordWebhook.new.notify_lottery_completed(@item.applicants + [ @item.user ], @item)
+      ActiveSupport::Notifications.instrument("lottery.completed", item: @item)
     else
-      @item.close!(by: :lottery)
+      @item.close(reason: :no_applicants)
     end
   end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -10,9 +10,6 @@ class Message < ApplicationRecord
   private
 
   def create_notifications
-    if (other_user = item.other_user_for(user))
-      Notification.create!(user: other_user, notifiable: self)
-      DiscordWebhook.new.notify_new_message(other_user, item)
-    end
+    ActiveSupport::Notifications.instrument("message.created", message: self)
   end
 end

--- a/config/initializers/active_support_notifications.rb
+++ b/config/initializers/active_support_notifications.rb
@@ -1,0 +1,64 @@
+Rails.application.reloader.to_prepare do
+  ActiveSupport::Notifications.subscribe "comment.created" do |*args|
+    event = ActiveSupport::Notifications::Event.new(*args)
+    comment = event.payload[:comment]
+    item = comment.item
+    recipients = item.watchers.where.not(id: comment.user_id)
+    next if recipients.empty?
+    DiscordWebhook.new.notify_new_comment(recipients, item)
+    recipients.each do |recipient|
+      Notification.create!(user: recipient, notifiable: comment)
+    end
+  end
+
+  ActiveSupport::Notifications.subscribe "message.created" do |*args|
+    event = ActiveSupport::Notifications::Event.new(*args)
+    message = event.payload[:message]
+    item = message.item
+    recipient = item.other_user_for(message.user)
+    next if recipient.nil?
+    DiscordWebhook.new.notify_new_message(recipient, item)
+    Notification.create!(user: recipient, notifiable: message)
+  end
+
+  ActiveSupport::Notifications.subscribe "item.published" do |*args|
+    event = ActiveSupport::Notifications::Event.new(*args)
+    item = event.payload[:item]
+    DiscordWebhook.new.notify_item_published(item)
+  end
+
+  ActiveSupport::Notifications.subscribe "item.deadline_extended" do |*args|
+    event = ActiveSupport::Notifications::Event.new(*args)
+    item = event.payload[:item]
+    DiscordWebhook.new.notify_item_deadline_extended(item.applicants, item)
+  end
+
+  ActiveSupport::Notifications.subscribe "item.closed" do |*args|
+    event = ActiveSupport::Notifications::Event.new(*args)
+    item = event.payload[:item]
+    reason = event.payload[:reason]
+    applicants = item.applicants
+    case reason
+    when :user_action
+      DiscordWebhook.new.notify_item_closed(applicants, item)
+      applicants.each do |applicant|
+        Notification.create!(user: applicant, notifiable: item)
+      end
+    when :no_applicants
+      DiscordWebhook.new.notify_lottery_skipped(item.user, item)
+      Notification.create!(user: item.user, notifiable: item)
+    end
+  end
+
+  ActiveSupport::Notifications.subscribe "lottery.completed" do |*args|
+    event = ActiveSupport::Notifications::Event.new(*args)
+    item = event.payload[:item]
+    seller = item.user
+    recipients = item.applicants + [ seller ]
+    DiscordWebhook.new.notify_lottery_completed(recipients, item)
+    item.entries.each do |entry|
+      Notification.create!(user: entry.user, notifiable: entry)
+    end
+    Notification.create!(user: seller, notifiable: item)
+  end
+end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Comment, type: :model do
+  let!(:webhook) { stub_discord_webhook }
+
   describe "validations" do
     context "when body is blank" do
       let(:comment) { build(:comment, body: nil) }
@@ -35,12 +37,12 @@ RSpec.describe Comment, type: :model do
     it "sends notification to watchers except commentator" do
       create(:watch, item: item, user: watcher)
       comment = build(:comment, user: commentator, item: item)
-
       expect { comment.save! }.to change(Notification, :count).by(2)
       expect(item.watchers.count).to eq(3)
 
       notified_users = Notification.where(notifiable: comment).pluck(:user_id)
       expect(notified_users).to contain_exactly(seller.id, watcher.id)
+      expect(webhook).to have_received(:notify_new_comment).with([ seller, watcher ], item)
     end
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -1,9 +1,7 @@
 require 'rails_helper'
 
-RSpec.describe Item, discord_stub: false, type: :model do
-  let(:webhook_double) { instance_double(DiscordWebhook, notify_item_published: true, notify_item_closed: true, notify_item_deadline_extended: true, notify_lottery_skipped: true) }
-
-  before { allow(DiscordWebhook).to receive(:new).and_return(webhook_double) }
+RSpec.describe Item, type: :model do
+  let!(:webhook) { stub_discord_webhook }
 
   describe "validations" do
     let(:item) { build(:item) }
@@ -209,15 +207,16 @@ RSpec.describe Item, discord_stub: false, type: :model do
     end
   end
 
-  describe "#close!" do
+  describe "#close" do
     context "when item is closed" do
       let(:user) { create(:user) }
       let(:item) { create(:item, :published, user: user) }
 
       it "changes status and clears entries" do
-        item.close!(by: :user)
+        item.close(reason: :user_action)
         expect(item.status).to eq("closed")
         expect(item.entries).to be_empty
+        expect(webhook).to have_received(:notify_item_closed)
       end
     end
   end
@@ -473,7 +472,7 @@ RSpec.describe Item, discord_stub: false, type: :model do
         item = create(:item)
         item.update!(status: :published)
 
-        expect(webhook_double).to have_received(:notify_item_published).with(item)
+        expect(webhook).to have_received(:notify_item_published).with(item)
       end
     end
 
@@ -483,7 +482,7 @@ RSpec.describe Item, discord_stub: false, type: :model do
       it "does not send webhook notification" do
         item.save!
 
-        expect(webhook_double).not_to have_received(:notify_item_published).with(item)
+        expect(webhook).not_to have_received(:notify_item_published).with(item)
       end
     end
 
@@ -491,11 +490,11 @@ RSpec.describe Item, discord_stub: false, type: :model do
       let(:item) { create(:item, :published, entry_deadline_at: Date.current) }
 
       it "does not send webhook notification" do
-        expect(webhook_double).to have_received(:notify_item_published).with(item).once
+        expect(webhook).to have_received(:notify_item_published).with(item).once
 
         item.update!(entry_deadline_at: Date.tomorrow)
 
-        expect(webhook_double).to have_received(:notify_item_published).with(item).once
+        expect(webhook).to have_received(:notify_item_published).with(item).once
       end
     end
   end
@@ -507,7 +506,7 @@ RSpec.describe Item, discord_stub: false, type: :model do
       it "sends webhook notification" do
         item.update!(entry_deadline_at: Date.tomorrow)
 
-        expect(webhook_double).to have_received(:notify_item_deadline_extended).with(item.applicants, item)
+        expect(webhook).to have_received(:notify_item_deadline_extended).with(item.applicants, item)
       end
     end
 
@@ -517,7 +516,7 @@ RSpec.describe Item, discord_stub: false, type: :model do
       it "does not send webhook notification" do
         item.update!(status: :published, entry_deadline_at: Date.tomorrow)
 
-        expect(webhook_double).not_to have_received(:notify_item_deadline_extended).with(item.applicants, item)
+        expect(webhook).not_to have_received(:notify_item_deadline_extended).with(item.applicants, item)
       end
     end
   end
@@ -530,10 +529,10 @@ RSpec.describe Item, discord_stub: false, type: :model do
       it "sends notification to applicants" do
         create(:entry, item: item, user: applicant)
 
-        item.close!(by: :user)
+        item.close(reason: :user_action)
 
         expect(Notification.last.user).to eq(applicant)
-        expect(webhook_double).to have_received(:notify_item_closed).with(item.applicants, item)
+        expect(webhook).to have_received(:notify_item_closed).with(item.applicants, item)
       end
     end
 
@@ -542,10 +541,10 @@ RSpec.describe Item, discord_stub: false, type: :model do
       let(:item) { create(:item, :published, user: seller, entry_deadline_at: Date.yesterday) }
 
       it "sends notification to seller" do
-        item.close!(by: :lottery)
+        item.close(reason: :no_applicants)
 
         expect(Notification.last.user).to eq(seller)
-        expect(webhook_double).to have_received(:notify_lottery_skipped).with(item.user, item)
+        expect(webhook).to have_received(:notify_lottery_skipped).with(item.user, item)
       end
     end
   end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Message, type: :model do
+  let!(:webhook) { stub_discord_webhook }
+
   describe "#create_notifications" do
     let(:seller) { create(:user) }
     let(:buyer) { create(:user) }
@@ -10,6 +12,7 @@ RSpec.describe Message, type: :model do
       it "creates notification to buyer" do
         create(:entry, :won, item: item, user: buyer)
         expect { create(:message, item: item, user: seller) }.to change { buyer.notifications.count }.by(1)
+        expect(webhook).to have_received(:notify_new_message).with(buyer, item)
       end
     end
 
@@ -17,6 +20,7 @@ RSpec.describe Message, type: :model do
       it "creates notification to seller" do
         create(:entry, :won, item: item, user: buyer)
         expect { create(:message, item: item, user: buyer) }.to change { seller.notifications.count }.by(1)
+        expect(webhook).to have_received(:notify_new_message).with(seller, item)
       end
     end
   end

--- a/spec/support/discord_webhook_stub.rb
+++ b/spec/support/discord_webhook_stub.rb
@@ -1,14 +1,21 @@
 module DiscordWebhookStub
   def stub_discord_webhook
     webhook = instance_double(DiscordWebhook)
-    allow(webhook).to receive(:notify_item_published)
-    allow(webhook).to receive(:notify_item_closed)
-    allow(webhook).to receive(:notify_item_deadline_extended)
-    allow(webhook).to receive(:notify_lottery_completed)
-    allow(webhook).to receive(:notify_lottery_skipped)
-    allow(webhook).to receive(:notify_new_comment)
-    allow(webhook).to receive(:notify_new_message)
+
+    [
+    :notify_item_published,
+    :notify_item_closed,
+    :notify_item_deadline_extended,
+    :notify_lottery_completed,
+    :notify_lottery_skipped,
+    :notify_new_comment,
+    :notify_new_message
+    ].each do |method|
+      allow(webhook).to receive(method)
+    end
 
     allow(DiscordWebhook).to receive(:new).and_return(webhook)
+
+    webhook
   end
 end


### PR DESCRIPTION
## Issue
- #188 
## 概要
Webhookとアプリ内通知の処理をActiveSupport::Notificationsを使って管理するようリファクタリングを行った。併せてテストの追加・リファクタリングも行った。