### PR TITLE
連絡ページを開くと関連の通知が既読になることのテストを追加

### DIFF
--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -14,7 +14,7 @@ header.px-3.sm:px-4.py-2.sticky.top-0.bg-white.z-10
               9v.75a8.967 8.967 0 0 1-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 0 1-5.714 0m5.714 0a3 3 0 1 1-5.714 0"
             - if current_user.has_unread_notifications?
               - display_count = current_user.notifications.unread.count > 99 ? "99+" : current_user.notifications.unread.count
-              span.absolute.top-1.left-5.min-w-5.px-1.bg-red-500.text-white.text-xs.font-bold.rounded-full.flex.items-center.justify-center
+              span#notification-count.absolute.top-1.left-5.min-w-5.px-1.bg-red-500.text-white.text-xs.font-bold.rounded-full.flex.items-center.justify-center
                 = display_count
           .flex.items-center.gap-2.h-full
             = image_tag (current_user.avatar_url.presence || "default-avatar.png"), alt: "", class: "w-9 h-9 rounded-full"
@@ -50,7 +50,7 @@ header.px-3.sm:px-4.py-2.sticky.top-0.bg-white.z-10
             - if current_user.has_unread_messages?
               - count = current_user.notifications.where(notifiable_type: "Message").unread.count
               - display_count = count > 99 ? "99+" : count
-              span.absolute.top-0.right-0.-translate-2.min-w-5.px-1.bg-red-500.text-white.text-xs.font-bold.rounded-full.flex.items-center.justify-center
+              span#message-count.absolute.top-0.right-0.-translate-2.min-w-5.px-1.bg-red-500.text-white.text-xs.font-bold.rounded-full.flex.items-center.justify-center
                 = display_count
   - else
     = link_to root_path do

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Notification, type: :model do
       it "returns won notification message" do
         notification = create(:notification, :for_entry, notifiable: entry, user: buyer)
 
-        expect(notification.message).to include("当選しました")
+        expect(notification.message).to include("購入が確定しました")
       end
     end
 
@@ -75,7 +75,7 @@ RSpec.describe Notification, type: :model do
       it "returns sold notification message" do
         notification = create(:notification, :for_item, notifiable: sold_item, user: seller)
 
-        expect(notification.message).to include("当選者が決まりました")
+        expect(notification.message).to include("購入者が決まりました")
       end
     end
 

--- a/spec/requests/items_spec.rb
+++ b/spec/requests/items_spec.rb
@@ -4,39 +4,11 @@ RSpec.describe "/items", type: :request do
   let(:user) { create(:user) }
   let(:admin) { create(:user, :admin, uid: "123") }
 
-  describe "GET /drafts" do
-    before { login(user) }
-
-    context "when draft exists" do
-      it "returns draft items with http success" do
-        draft_item = create(:item, user: user)
-        published_item = create(:item, :published, user: user)
-
-        get drafts_path
-
-        expect(response).to have_http_status(:success)
-        expect(response.body).to include(draft_item.title)
-        expect(response.body).not_to include(published_item.title)
-      end
-    end
-
-    context "when no draft exists" do
-      it "returns message with http success" do
-        published_item = create(:item, :published, user: user)
-        get drafts_path
-
-        expect(response).to have_http_status(:success)
-        expect(response.body).to include("下書きはありません")
-        expect(response.body).not_to include(published_item.title)
-      end
-    end
-  end
-
   describe "GET /listings" do
     before { login(user) }
 
     context "when listings exists" do
-      it "returns items without draft with http success" do
+      it "returns items with draft with http success" do
         draft_item = create(:item, user: user)
         published_item = create(:item, :published, user: user)
         sold_item = create(:item, :sold, user: user)
@@ -47,18 +19,16 @@ RSpec.describe "/items", type: :request do
         expect(response.body).to include(published_item.title)
         expect(response.body).to include(sold_item.title)
         expect(response.body).to include(closed_item.title)
-        expect(response.body).not_to include(draft_item.title)
+        expect(response.body).to include(draft_item.title)
       end
     end
 
     context "when no listings exists" do
       it "return message with http success" do
-        draft_item = create(:item, user: user)
         get listings_path
 
         expect(response).to have_http_status(:success)
         expect(response.body).to include("該当する商品はありません")
-        expect(response.body).not_to include(draft_item.title)
       end
     end
 
@@ -225,9 +195,9 @@ RSpec.describe "/items", type: :request do
         }.to change(Item, :count).by(1)
       end
 
-      it "redirects to the drafts" do
+      it "redirects to the listings" do
         post items_url, params: { item: valid_attributes }
-        expect(response).to redirect_to(drafts_path)
+        expect(response).to redirect_to(listings_path)
       end
     end
   end
@@ -298,11 +268,11 @@ RSpec.describe "/items", type: :request do
         expect(item.title).to eq("初版")
       end
 
-      it "redirects to the drafts" do
+      it "redirects to the listings" do
         item = create(:item, user: user, title: "技術書")
         patch item_url(item), params: { item: new_attributes }
         item.reload
-        expect(response).to redirect_to(drafts_path)
+        expect(response).to redirect_to(listings_path)
       end
     end
   end
@@ -318,10 +288,10 @@ RSpec.describe "/items", type: :request do
         }.to change(Item, :count).by(-1)
       end
 
-      it "redirects to the drafts list" do
+      it "redirects to the listings" do
         item = create(:item, user: user)
         delete item_url(item)
-        expect(response).to redirect_to(drafts_url)
+        expect(response).to redirect_to(listings_url)
       end
     end
 

--- a/spec/requests/messages_spec.rb
+++ b/spec/requests/messages_spec.rb
@@ -23,6 +23,15 @@ RSpec.describe "/messages", type: :request do
         get transaction_messages_path(item)
         expect(response).to be_successful
       end
+
+      it "makes all messages read" do
+        create(:entry, :won, item: item, user: buyer)
+        create_list(:message, 2, user: seller, item: item)
+        login(buyer)
+        expect(buyer.notifications.pluck(:read)).to all(be false)
+        get transaction_messages_path(item)
+        expect(buyer.notifications.reload.pluck(:read)).to all(be true)
+      end
     end
   end
 

--- a/spec/system/items_spec.rb
+++ b/spec/system/items_spec.rb
@@ -30,9 +30,9 @@ RSpec.describe "Items", type: :system do
       expect(page).to have_current_path(items_path)
 
       visit listings_path
-      click_on "購入者確定"
+      click_on "購入者決定"
 
-      expect(page).to have_css("a.active-tab", text: "購入者確定")
+      expect(page).to have_css("a.active-tab", text: "購入者決定")
       expect(page).not_to have_content("#{published_item.title}")
       expect(page).not_to have_content("#{closed_item.title}")
       expect(page).to have_content("#{sold_item.title}")
@@ -115,7 +115,7 @@ RSpec.describe "Items", type: :system do
         fill_in '商品名', with: '技術書'
         click_on '下書きとして保存する'
 
-        expect(page).to have_current_path(drafts_path)
+        expect(page).to have_current_path(listings_path)
         expect(page).to have_content('技術書')
       end
     end
@@ -126,7 +126,7 @@ RSpec.describe "Items", type: :system do
 
         click_on '出品する'
         fill_in '商品名', with: '技術書'
-        attach_file '商品画像', "#{Rails.root}/spec/fixtures/files/book1.png"
+        attach_file "item[images][]", "#{Rails.root}/spec/fixtures/files/book1.png", make_visible: true, match: :first
         fill_in '価格', with: 1000
         choose '出品者'
         fill_in 'お支払い方法', with: 'PayPay'
@@ -172,12 +172,12 @@ RSpec.describe "Items", type: :system do
         create(:item, user: user, title: '技術書')
         expect(page).to have_current_path(items_path)
 
-        visit drafts_path
+        visit listings_path
         click_on '技術書'
         fill_in '商品名', with: '小説'
         click_on '上書き保存する'
 
-        expect(page).to have_current_path(drafts_path)
+        expect(page).to have_current_path(listings_path)
         expect(page).to have_content('小説')
       end
     end
@@ -187,7 +187,7 @@ RSpec.describe "Items", type: :system do
         item = create(:item, :with_item_image, user: user, title: '技術書')
         expect(page).to have_current_path(items_path)
 
-        visit drafts_path
+        visit listings_path
         click_on '技術書'
         fill_in '商品名', with: '小説'
         click_button '出品する'
@@ -217,15 +217,17 @@ RSpec.describe "Items", type: :system do
     context "when deleting draft" do
       before { login(user) }
 
-      it "deletes item and redirects to drafts index" do
+      it "deletes item and redirects to listings index" do
         create(:item, user: user, title: '技術書')
         expect(page).to have_current_path(items_path)
 
-        visit drafts_path
+        visit listings_path
         click_on '技術書'
-        click_on '削除する'
+        accept_confirm do
+          click_on '削除する'
+        end
 
-        expect(page).to have_current_path(drafts_path)
+        expect(page).to have_current_path(listings_path)
         expect(page).not_to have_content('技術書')
         expect(page).to have_content('下書きを削除しました')
       end

--- a/spec/system/notifications_spec.rb
+++ b/spec/system/notifications_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe "Notifications", type: :system do
       click_on "未読"
       expect(page).to have_css("a.border-b-2", text: "未読")
       expect(page).to have_content("「#{closed_item.title}」は当選者なしで公開終了しました。")
-      expect(page).not_to have_content("「#{sold_item.title}」の抽選が完了し、当選者が決まりました。")
+      expect(page).not_to have_content("「#{sold_item.title}」の購入者が決まりました。")
     end
 
     it "shows all notifications when all tab is clicked" do
@@ -117,7 +117,7 @@ RSpec.describe "Notifications", type: :system do
       click_on "全て", exact: true
       expect(page).to have_css("a.border-b-2", text: "全て")
       expect(page).to have_content("「#{closed_item.title}」は当選者なしで公開終了しました。")
-      expect(page).to have_content("「#{sold_item.title}」の抽選が完了し、当選者が決まりました。")
+      expect(page).to have_content("「#{sold_item.title}」の購入者が決まりました。")
     end
   end
 end

--- a/spec/system/notifications_spec.rb
+++ b/spec/system/notifications_spec.rb
@@ -79,7 +79,8 @@ RSpec.describe "Notifications", type: :system do
         expect(page).to have_current_path(items_path)
 
         visit items_path
-        expect(page).to have_css("span.absolute", text: "99+")
+
+        expect(page).to have_selector("#notification-count", text: "99+")
       end
     end
 
@@ -89,7 +90,7 @@ RSpec.describe "Notifications", type: :system do
 
         visit notifications_path
 
-        expect(page).not_to have_css("span.absolute")
+        expect(page).not_to have_css("#notification-count")
         expect(page).to have_content("通知はありません")
       end
     end
@@ -118,6 +119,19 @@ RSpec.describe "Notifications", type: :system do
       expect(page).to have_css("a.border-b-2", text: "全て")
       expect(page).to have_content("「#{closed_item.title}」は当選者なしで公開終了しました。")
       expect(page).to have_content("「#{sold_item.title}」の購入者が決まりました。")
+    end
+  end
+
+  describe "message notification count" do
+    context "when over 99 notifications exists" do
+      it "shows 99+ count on notification icon" do
+        create_list(:notification, 100, :for_message, user: user)
+        expect(page).to have_current_path(items_path)
+
+        visit items_path
+
+        expect(page).to have_selector("#message-count", text: "99+")
+      end
     end
   end
 end


### PR DESCRIPTION
## Issue
- #212 
## 概要
既読テストと連絡ページの通知数表示にテストを追加し、その他の通っていなかったテストの修正を行った。