### PR TITLE
グローバルナビの表示変更、turboのプリフェッチの無効化

### DIFF
--- a/app/views/items/show.html.slim
+++ b/app/views/items/show.html.slim
@@ -174,7 +174,7 @@ article.item-show.mt-2.flex.flex-col.md:grid.md:grid-cols-2.md:gap-10.md:items-s
         - else
           - if current_user.entry_for(@item)&.won?
             .bg-cyan-50.border.border-cyan-300.rounded-xl.p-5
-              .flex.items-center.justify-center.gap-2.mb-2
+              .flex.items-center.gap-2.mb-2
                 svg.text-cyan-700 xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-5"
                   path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
                 span.font-semibold.text-cyan-800 当選しました！

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -22,6 +22,8 @@ html
     meta[name="apple-mobile-web-app-title" content="FjordStand"]
     meta[name="application-name" content="FjordStand"]
 
+    meta[name="turbo-prefetch" content="false"]
+
     = csrf_meta_tags
     = csp_meta_tag
 

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -3,8 +3,8 @@ header.site-header.sticky.top-0.bg-white.z-10.border-b.border-gray-200.shadow-sm
     ruby:
       on_items = [ items_path, watches_path ].any? { |p| current_page?(p) }
       on_entries = current_page?(entries_path)
-      on_listings = current_page?(listings_path)
-      on_transactions = current_page?(transactions_path)
+      on_listings = [ new_item_path, listings_path ].any? { |p| current_page?(p) } || request.path.match?(%r{\A/items/\d+/edit\z})
+      on_transactions = request.path.start_with?(transactions_path)
       active_cls  = "nav-link nav-link--active bg-white text-gray-900 font-semibold rounded-full px-2 sm:px-4 py-1.5 shadow-sm text-sm flex flex-row \
       flex-wrap items-center justify-center content-center"
       inactive_cls = "nav-link text-gray-500 rounded-full px-2 sm:px-4 py-1.5 hover:text-gray-800 transition-colors text-sm flex flex-row flex-wrap \

--- a/app/views/transactions/index.html.slim
+++ b/app/views/transactions/index.html.slim
@@ -36,6 +36,6 @@ h1.page-title.font-bold.text-2xl.mb-6.text-gray-900.text-center 連絡ページ�
               svg.text-gray-400 xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-5"
                 path stroke-linecap="round" stroke-linejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5"
           - if item.unread_messages_for?(current_user)
-            span.absolute.top-3.left-3.px-3.py-1.text-xs.font-semibold.text-white.bg-red-500.rounded-full 未読
+            span.absolute.top-3.left-3.px-3.py-1.text-xs.font-bold.text-white.shadow-sm.text-center.bg-red-500.rounded-full 未読
   .pagination.mt-6
     = paginate @items


### PR DESCRIPTION
## Issue
- #195 
## 概要
商品作成・編集時に自分の出品タブが強調表示されるようにグローバルナビの表示を変更し、また、ホバーで通知が既読に変更されないようturboのプリフェッチを無効にした。