### PR TITLE
抽選が行われなかった時に2重にアプリ内通知を作らないよう修正

### DIFF
--- a/app/jobs/notify_lottery_results_job.rb
+++ b/app/jobs/notify_lottery_results_job.rb
@@ -23,7 +23,7 @@ class NotifyLotteryResultsJob < ApplicationJob
     end
     ActiveRecord::Base.transaction do
       Notification.insert_all!(notifications) if notifications.any?
-      Notification.create!(user: item.user, notifiable: item)
+      Notification.create!(user: item.user, notifiable: item) if item.entries.any?
     end
     DiscordWebhook.new.notify_lottery_completed(item.applicants + [ item.user ], item)
   end

--- a/spec/jobs/notify_lottery_results_job_spec.rb
+++ b/spec/jobs/notify_lottery_results_job_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe NotifyLotteryResultsJob, type: :job do
-    let!(:webhook) { stub_discord_webhook }
+  let!(:webhook) { stub_discord_webhook }
 
   let(:seller) { create(:user) }
   let(:item) { create(:item, :sold, user: seller) }
@@ -21,6 +21,15 @@ RSpec.describe NotifyLotteryResultsJob, type: :job do
     it "sends webhook notification" do
       described_class.perform_now(item.id)
       expect(webhook).to have_received(:notify_lottery_completed).with([ winner, seller ], item)
+    end
+
+    context 'when item has no applicants' do
+      let(:closed_item) { create(:item, :closed, user: seller) }
+
+      it 'does not create an item notification' do
+        expect { described_class.perform_now(closed_item.id) }.not_to change(Notification, :count)
+        expect(webhook).to have_received(:notify_lottery_completed).with([ seller ], closed_item)
+      end
     end
   end
 end


### PR DESCRIPTION
## Issue
- #254 
## 概要
NotifyLotteryResultsJobで抽選があった時のみ出品者にアプリ内通知を送るよう修正した。合わせてテストを追加した。