### PR TITLE
通知一覧のN+1懸念を解消

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,7 +1,7 @@
 class NotificationsController < ApplicationController
   def index
     @notifications = current_user.notifications
-                                  .preload(notifiable: [:user, { item: [:user, :winner] }])
+                                  .preload(notifiable: [ :user, { item: [ :user, :winner ] } ])
                                   .by_target(params[:status])
                                   .order(created_at: :desc)
                                   .page(params[:page])

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,7 +1,7 @@
 class NotificationsController < ApplicationController
   def index
     @notifications = current_user.notifications
-                                  .includes(:notifiable)
+                                  .preload(notifiable: [:user, { item: [:user, :winner] }])
                                   .by_target(params[:status])
                                   .order(created_at: :desc)
                                   .page(params[:page])

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -13,8 +13,8 @@ class Notification < ApplicationRecord
 
   def message
     case notifiable
-    when Message
-      "#{notifiable.item.other_user_for(user).name}さんから「#{notifiable.item.title}」についてメッセージが届きました。"
+    when Comment
+      "#{notifiable.user.name}さんが「#{notifiable.item.title}」についてコメントしました。"
     when Entry
       if notifiable.won?
         "「#{notifiable.item.title}」の購入が確定しました！連絡ページから出品者へご連絡ください。"
@@ -27,15 +27,15 @@ class Notification < ApplicationRecord
       else
         "「#{notifiable.title}」は当選者なしで公開終了しました。"
       end
-    when Comment
-      "#{notifiable.user.name}さんが「#{notifiable.item.title}」についてコメントしました。"
+    when Message
+      "#{notifiable.item.other_user_for(user).name}さんから「#{notifiable.item.title}」についてメッセージが届きました。"
     end
   end
 
   def link
     case notifiable
-    when Message
-      Rails.application.routes.url_helpers.transaction_messages_path(notifiable.item)
+    when Comment
+      Rails.application.routes.url_helpers.item_path(notifiable.item)
     when Entry
       if notifiable.won?
         Rails.application.routes.url_helpers.transaction_messages_path(notifiable.item)
@@ -48,8 +48,8 @@ class Notification < ApplicationRecord
       else
         Rails.application.routes.url_helpers.item_path(notifiable)
       end
-    when Comment
-      Rails.application.routes.url_helpers.item_path(notifiable.item)
+    when Message
+      Rails.application.routes.url_helpers.transaction_messages_path(notifiable.item)
     end
   end
 end


### PR DESCRIPTION
## Issue
- #265 

## 概要
通知一覧のN+1懸念を解消できるpreloadを追加し、順番がわかりづらかったNotification#message/#linkのcase/whenの順番をabc順に変更した。