### PR TITLE
既読処理にユーザーのnil安全性を追加・商品詳細の既読処理を修正

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -19,10 +19,12 @@ class ItemsController < ApplicationController
   def show
     @comment = Comment.new
     @comments = @item.comments.includes(:user).order(created_at: :asc)
-    current_user.notifications
-                .unread
-                .where(notifiable_type: "Comment", notifiable_id: @item.comment_ids)
-                .update_all(read: true)
+    if params[:from] == "notifications" && current_user
+      current_user.notifications
+                  .unread
+                  .where(notifiable_type: "Comment", notifiable_id: @item.comment_ids)
+                  .update_all(read: true)
+    end
   end
 
   # GET /items/new

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -8,6 +8,8 @@ class MessagesController < ApplicationController
   def index
     @messages = @item.messages.includes(:user).order(:created_at)
     @message = @item.messages.build
+    return unless current_user
+
     current_user.notifications
                 .unread
                 .where(notifiable_type: "Message", notifiable_id: @item.message_ids)

--- a/app/views/notifications/index.html.slim
+++ b/app/views/notifications/index.html.slim
@@ -21,7 +21,7 @@ h1.font-bold.text-2xl.mb-6.text-gray-900.text-center 通知一覧
     - else
       = paginate @notifications
       - @notifications.each do |notification|
-        = link_to notification_read_path(notification), data: { turbo_method: :patch, turbo_frame: "_top" }, class: "block my-2" do
+        = link_to notification_read_path(notification, from: :notifications), data: { turbo_method: :patch, turbo_frame: "_top" }, class: "block my-2" do
           .bg-white.rounded-xl.border.border-gray-200.shadow-sm.p-4.hover:shadow-md.transition-shadow.duration-200
             - if !notification.read?
               span.inline-block.px-2.mr-2.text-xs.font-semibold.text-red-600.bg-red-100.rounded-full class="py-0.5" 未読

--- a/spec/requests/items_spec.rb
+++ b/spec/requests/items_spec.rb
@@ -35,6 +35,26 @@ RSpec.describe "/items", type: :request do
       get item_url(item)
       expect(response).to be_successful
     end
+
+    context "when accessed from notifications" do
+      it "makes all notifications read" do
+        item = create(:item, :published, user: user)
+        create_list(:comment, 2, item: item, user: admin)
+        expect(user.notifications.pluck(:read)).to all(be false)
+        get items_path(item, from: :notifications)
+        expect(user.notifications.reload.pluck(:read)).to all(be true)
+      end
+    end
+
+    context "when accessed not from notifications" do
+      it "does not change notifications read status" do
+        item = create(:item, :published, user: user)
+        create_list(:comment, 2, item: item, user: admin)
+        expect(user.notifications.pluck(:read)).to all(be false)
+        get items_path(item)
+        expect(user.notifications.reload.pluck(:read)).to all(be false)
+      end
+    end
   end
 
   describe "GET /new" do

--- a/spec/requests/items_spec.rb
+++ b/spec/requests/items_spec.rb
@@ -28,10 +28,9 @@ RSpec.describe "/items", type: :request do
   end
 
   describe "GET /show" do
-    before { login(user) }
-
     it "renders a successful response" do
       item = create(:item, :published)
+      login(user)
       get item_url(item)
       expect(response).to be_successful
     end
@@ -41,7 +40,8 @@ RSpec.describe "/items", type: :request do
         item = create(:item, :published, user: user)
         create_list(:comment, 2, item: item, user: admin)
         expect(user.notifications.pluck(:read)).to all(be false)
-        get items_path(item, from: :notifications)
+        login(user)
+        get item_path(item, from: :notifications)
         expect(user.notifications.reload.pluck(:read)).to all(be true)
       end
     end
@@ -51,7 +51,8 @@ RSpec.describe "/items", type: :request do
         item = create(:item, :published, user: user)
         create_list(:comment, 2, item: item, user: admin)
         expect(user.notifications.pluck(:read)).to all(be false)
-        get items_path(item)
+        login(user)
+        get item_path(item)
         expect(user.notifications.reload.pluck(:read)).to all(be false)
       end
     end


### PR DESCRIPTION
## Issue
- #267 
## 概要
連絡ページの関連通知既読処理にnil安全性を追加した。また、商品詳細閲覧時にコメント欄関連通知が既読になっていたのを通知一覧から飛んだ時だけ既読にするよう修正しテストを追加した。