### PR TITLE
admin設定をuidを使わず維持するコードに変更

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -8,8 +8,6 @@ class SessionsController < ApplicationController
       reset_session
       session[:user_id] = user.id
       redirect_to items_path, notice: "ログインしました"
-    elsif user == :not_member
-      redirect_to root_path, alert: "FjordBootCampのDiscordサーバーに参加していません"
     else
       redirect_to root_path, alert: "ログインに失敗しました"
     end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -8,8 +8,10 @@ class SessionsController < ApplicationController
       reset_session
       session[:user_id] = user.id
       redirect_to items_path, notice: "ログインしました"
-    else
+    elsif user == :not_member
       redirect_to root_path, alert: "FjordBootCampのDiscordサーバーに参加していません"
+    else
+      redirect_to root_path, alert: "ログインに失敗しました"
     end
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -9,7 +9,7 @@ class SessionsController < ApplicationController
       session[:user_id] = user.id
       redirect_to items_path, notice: "ログインしました"
     else
-      redirect_to root_path, alert: "ログインに失敗しました"
+      redirect_to root_path, alert: "FjordBootCampのDiscordサーバーに参加していません"
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,7 +20,6 @@ class User < ApplicationRecord
     if user.new_record?
       user.admin = (auth.uid == owner_id)
     end
-    user.admin = true if auth.uid == owner_id && user.new_record?
     user.provider = auth.provider if user.provider.blank?
     user.name = auth.extra.raw_info["global_name"].presence || auth.info.name
     user.avatar_url = auth.info.image

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,17 +8,16 @@ class User < ApplicationRecord
   has_many :notifications, dependent: :destroy
 
   def self.from_omniauth(auth)
-    guild = Discordrb::API::Server.resolve("Bot #{ENV['DISCORD_BOT_TOKEN']}", ENV["DISCORD_SERVER_ID"])
-    owner_id = JSON.parse(guild)["owner_id"]
-
     begin
       Discordrb::API::Server.resolve_member("Bot #{ENV['DISCORD_BOT_TOKEN']}", ENV["DISCORD_SERVER_ID"], auth.uid)
     rescue Discordrb::Errors::UnknownMember
       return nil
     end
 
-    user = find_or_initialize_by(uid: auth.uid)
+    guild = Discordrb::API::Server.resolve("Bot #{ENV['DISCORD_BOT_TOKEN']}", ENV["DISCORD_SERVER_ID"])
+    owner_id = JSON.parse(guild)["owner_id"]
 
+    user = find_or_initialize_by(uid: auth.uid)
     user.admin = true if auth.uid == owner_id && user.new_record?
     user.provider = auth.provider if user.provider.blank?
     user.name = auth.extra.raw_info["global_name"].presence || auth.info.name

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,12 +18,13 @@ class User < ApplicationRecord
     end
 
     user = find_or_initialize_by(uid: auth.uid)
-    admin_status = user.persisted? ? (user.admin? || owner_id == auth.uid) : (owner_id == auth.uid)
+    if user.new_record?
+      user.provider = auth.provider
+      user.admin = true if auth.uid == owner_id
+    end
     user.update!(
-      provider: auth.provider,
       name: auth.extra.raw_info["global_name"].presence || auth.info.name,
-      avatar_url: auth.info.image,
-      admin: admin_status
+      avatar_url: auth.info.image
       )
     user
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,7 +15,7 @@ class User < ApplicationRecord
     begin
       Discordrb::API::Server.resolve_member("Bot #{ENV['DISCORD_BOT_TOKEN']}", ENV["DISCORD_SERVER_ID"], auth.uid)
     rescue Discordrb::Errors::UnknownMember
-      return nil
+      return :not_member
     end
 
     user = find_or_initialize_by(uid: auth.uid, provider: auth.provider)
@@ -39,8 +39,11 @@ class User < ApplicationRecord
       user.avatar_url = new_avatar_url if user.avatar_url != new_avatar_url
     end
 
-    user.save!
-    user
+    if user.save
+      user
+    else
+      nil
+    end
   end
 
   def entry_for(item)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,7 +22,7 @@ class User < ApplicationRecord
       provider: auth.provider,
       name: auth.extra.raw_info["global_name"].presence || auth.info.name,
       avatar_url: auth.info.image,
-      admin: user.admin || (owner_id == auth.uid)
+      admin: (owner_id == auth.uid) || (user.persisted? && user.admin?)
       )
     user
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,7 +15,7 @@ class User < ApplicationRecord
     begin
       Discordrb::API::Server.resolve_member("Bot #{ENV['DISCORD_BOT_TOKEN']}", ENV["DISCORD_SERVER_ID"], auth.uid)
     rescue Discordrb::Errors::UnknownMember
-      return :not_member
+      return nil
     end
 
     user = find_or_initialize_by(uid: auth.uid, provider: auth.provider)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,7 +26,10 @@ class User < ApplicationRecord
     user.name = auth.extra.raw_info["global_name"].presence || auth.info.name
     user.avatar_url = auth.info.image
 
-    user.save!
+    if user.has_changes_to_save?
+      user.save!
+    end
+
     user
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,6 +17,7 @@ class User < ApplicationRecord
     guild = Discordrb::API::Server.resolve("Bot #{ENV['DISCORD_BOT_TOKEN']}", ENV["DISCORD_SERVER_ID"])
     owner_id = JSON.parse(guild)["owner_id"]
 
+    user = find_or_initialize_by(uid: auth.uid)
     if user.new_record?
       user.admin = (auth.uid == owner_id)
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,14 +18,13 @@ class User < ApplicationRecord
     end
 
     user = find_or_initialize_by(uid: auth.uid)
-    if user.new_record?
-      user.provider = auth.provider
-      user.admin = true if auth.uid == owner_id
-    end
-    user.update!(
-      name: auth.extra.raw_info["global_name"].presence || auth.info.name,
-      avatar_url: auth.info.image
-      )
+
+    user.admin = true if auth.uid == owner_id && user.new_record?
+    user.provider = auth.provider if user.provider.blank?
+    user.name = auth.extra.raw_info["global_name"].presence || auth.info.name
+    user.avatar_url = auth.info.image
+
+    user.save!
     user
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,11 +14,12 @@ class User < ApplicationRecord
       return nil
     end
 
-    guild = Discordrb::API::Server.resolve("Bot #{ENV['DISCORD_BOT_TOKEN']}", ENV["DISCORD_SERVER_ID"])
-    owner_id = JSON.parse(guild)["owner_id"]
-
     user = find_or_initialize_by(uid: auth.uid)
+
     if user.new_record?
+      guild = Discordrb::API::Server.resolve("Bot #{ENV['DISCORD_BOT_TOKEN']}", ENV["DISCORD_SERVER_ID"])
+      owner_id = JSON.parse(guild)["owner_id"]
+
       user.admin = (auth.uid == owner_id)
     end
     user.provider = auth.provider if user.provider.blank?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,8 +20,8 @@ class User < ApplicationRecord
 
     user = find_or_initialize_by(uid: auth.uid, provider: auth.provider)
 
-    auth_global_name = auth.dig("extra", "raw_info", "global_name")
-    auth_name = auth.dig("info", "name")
+    auth_global_name = auth.dig(:extra, :raw_info, :global_name)
+    auth_name = auth.dig(:info, :name)
     incoming_name = auth_global_name.presence || auth_name.presence
     if user.new_record?
       guild = Discordrb::API::Server.resolve("Bot #{ENV['DISCORD_BOT_TOKEN']}", ENV["DISCORD_SERVER_ID"])
@@ -33,7 +33,7 @@ class User < ApplicationRecord
     else
       user.name = incoming_name if incoming_name.present? && user.name != incoming_name
     end
-    auth_image = auth.dig("info", "image")
+    auth_image = auth.dig(:info, :image)
     if auth_image.present?
       new_avatar_url = URI.parse(auth_image).tap { |uri| uri.query = nil }.to_s
       user.avatar_url = new_avatar_url if user.avatar_url != new_avatar_url

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,7 +22,7 @@ class User < ApplicationRecord
       provider: auth.provider,
       name: auth.extra.raw_info["global_name"].presence || auth.info.name,
       avatar_url: auth.info.image,
-      admin: user.admin? || (owner_id == auth.uid)
+      admin: user.admin || (owner_id == auth.uid)
       )
     user
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,11 +18,7 @@ class User < ApplicationRecord
     end
 
     user = find_or_initialize_by(uid: auth.uid)
-    if user.persisted?
-      admin_status = user.admin?
-    else
-      admin_status = (owner_id == auth.uid)
-    end
+    admin_status = user.persisted? ? (user.admin? || owner_id == auth.uid) : (owner_id == auth.uid)
     user.update!(
       provider: auth.provider,
       name: auth.extra.raw_info["global_name"].presence || auth.info.name,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,10 @@ class User < ApplicationRecord
   has_many :watches, dependent: :destroy
   has_many :notifications, dependent: :destroy
 
+  validates :provider, presence: true
+  validates :uid, presence: true, uniqueness: { scope: :provider }
+  validates :name, presence: true
+
   def self.from_omniauth(auth)
     begin
       Discordrb::API::Server.resolve_member("Bot #{ENV['DISCORD_BOT_TOKEN']}", ENV["DISCORD_SERVER_ID"], auth.uid)
@@ -14,22 +18,28 @@ class User < ApplicationRecord
       return nil
     end
 
-    user = find_or_initialize_by(uid: auth.uid)
+    user = find_or_initialize_by(uid: auth.uid, provider: auth.provider)
 
+    auth_global_name = auth.dig("extra", "raw_info", "global_name")
+    auth_name = auth.dig("info", "name")
+    incoming_name = auth_global_name.presence || auth_name.presence
     if user.new_record?
       guild = Discordrb::API::Server.resolve("Bot #{ENV['DISCORD_BOT_TOKEN']}", ENV["DISCORD_SERVER_ID"])
       owner_id = JSON.parse(guild)["owner_id"]
 
       user.admin = (auth.uid == owner_id)
+      user.provider = auth.provider
+      user.name = incoming_name || "ユーザー_#{auth.uid}"
+    else
+      user.name = incoming_name if incoming_name.present? && user.name != incoming_name
     end
-    user.provider = auth.provider if user.provider.blank?
-    user.name = auth.extra.raw_info["global_name"].presence || auth.info.name
-    user.avatar_url = auth.info.image
-
-    if user.has_changes_to_save?
-      user.save!
+    auth_image = auth.dig("info", "image")
+    if auth_image.present?
+      new_avatar_url = URI.parse(auth_image).tap { |uri| uri.query = nil }.to_s
+      user.avatar_url = new_avatar_url if user.avatar_url != new_avatar_url
     end
 
+    user.save!
     user
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,7 +22,7 @@ class User < ApplicationRecord
       provider: auth.provider,
       name: auth.extra.raw_info["global_name"].presence || auth.info.name,
       avatar_url: auth.info.image,
-      admin: (owner_id == auth.uid) || (auth.uid == "850718521234948146")
+      admin: user.admin? || (owner_id == auth.uid)
       )
     user
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,11 +18,16 @@ class User < ApplicationRecord
     end
 
     user = find_or_initialize_by(uid: auth.uid)
+    if user.persisted?
+      admin_status = user.admin?
+    else
+      admin_status = (owner_id == auth.uid)
+    end
     user.update!(
       provider: auth.provider,
       name: auth.extra.raw_info["global_name"].presence || auth.info.name,
       avatar_url: auth.info.image,
-      admin: (owner_id == auth.uid) || (user.persisted? && user.admin?)
+      admin: admin_status
       )
     user
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,7 +17,9 @@ class User < ApplicationRecord
     guild = Discordrb::API::Server.resolve("Bot #{ENV['DISCORD_BOT_TOKEN']}", ENV["DISCORD_SERVER_ID"])
     owner_id = JSON.parse(guild)["owner_id"]
 
-    user = find_or_initialize_by(uid: auth.uid)
+    if user.new_record?
+      user.admin = (auth.uid == owner_id)
+    end
     user.admin = true if auth.uid == owner_id && user.new_record?
     user.provider = auth.provider if user.provider.blank?
     user.name = auth.extra.raw_info["global_name"].presence || auth.info.name

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,7 +28,6 @@ class User < ApplicationRecord
       owner_id = JSON.parse(guild)["owner_id"]
 
       user.admin = (auth.uid == owner_id)
-      user.provider = auth.provider
       user.name = incoming_name || "ユーザー_#{auth.uid}"
     else
       user.name = incoming_name if incoming_name.present? && user.name != incoming_name

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,8 +8,8 @@ class User < ApplicationRecord
   has_many :notifications, dependent: :destroy
 
   def self.from_omniauth(auth)
-    guild_info = Discordrb::API::Server.resolve("Bot #{ENV['DISCORD_BOT_TOKEN']}", ENV["DISCORD_SERVER_ID"])
-    owner_id = JSON.parse(guild_info)["owner_id"]
+    guild = Discordrb::API::Server.resolve("Bot #{ENV['DISCORD_BOT_TOKEN']}", ENV["DISCORD_SERVER_ID"])
+    owner_id = JSON.parse(guild)["owner_id"]
 
     begin
       Discordrb::API::Server.resolve_member("Bot #{ENV['DISCORD_BOT_TOKEN']}", ENV["DISCORD_SERVER_ID"], auth.uid)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,19 +30,20 @@ class User < ApplicationRecord
       user.admin = (auth.uid == owner_id)
       user.name = incoming_name || "ユーザー_#{auth.uid}"
     else
-      user.name = incoming_name if incoming_name.present? && user.name != incoming_name
+      if incoming_name.present? && user.name != incoming_name
+        user.name = incoming_name
+      end
+      user.name ||= "ユーザー_#{auth.uid}"
     end
+
     auth_image = auth.dig(:info, :image)
     if auth_image.present?
       new_avatar_url = URI.parse(auth_image).tap { |uri| uri.query = nil }.to_s
       user.avatar_url = new_avatar_url if user.avatar_url != new_avatar_url
     end
 
-    if user.save
-      user
-    else
-      nil
-    end
+    user.save!
+    user
   end
 
   def entry_for(item)

--- a/db/migrate/20260603081537_change_unique_index_on_users.rb
+++ b/db/migrate/20260603081537_change_unique_index_on_users.rb
@@ -1,0 +1,7 @@
+class ChangeUniqueIndexOnUsers < ActiveRecord::Migration[8.1]
+  def change
+    remove_index :users, name: "index_users_on_uid"
+
+    add_index :users, [:uid, :provider], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_22_072710) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_03_081537) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -227,7 +227,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_22_072710) do
     t.string "provider", null: false
     t.string "uid", null: false
     t.datetime "updated_at", null: false
-    t.index ["uid"], name: "index_users_on_uid", unique: true
+    t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 
   create_table "watches", force: :cascade do |t|

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     name { Faker::Name.name }
     sequence(:uid) { |n| "123456789#{n}" }
     provider { "discord" }
-    avatar_url { Faker::Avatar.image }
+    avatar_url { nil }
     admin { false }
   end
 


### PR DESCRIPTION
## Issue
- #264 
## 概要
- uidを指定して今のadminであるアプリ制作者のadminを保とうとしていたが、ユーザー登録時にDiscordサーバーオーナーをadminに設定するコードに修正した。
- uidをproviderごとにユニークにするようDBを変更し、モデルバリデーションを追加した。
- 新規ユーザー登録時のみDiscordサーバーオーナーを確認するよう修正。