### PR TITLE
SessionsControllerのテストの追加・修正

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -14,7 +14,7 @@ class SessionsController < ApplicationController
   end
 
   def failure
-    redirect_to root_path, alert: "ログインがキャンセルされました"
+    redirect_to root_path
   end
 
   def destroy

--- a/spec/system/notifications_spec.rb
+++ b/spec/system/notifications_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "Notifications", type: :system do
         visit notifications_path(status: "unread")
         expect(page).to have_css("span.absolute", text: "2")
 
-        find("a[href='#{notification_read_path(notification_for_closed_item)}']").click
+        find("a[href='#{notification_read_path(notification_for_closed_item)}?from=notifications']").click
 
         expect(page).to have_current_path("#{item_path(closed_item)}?from=notifications")
         expect(page).to have_css("span.absolute", text: "1")

--- a/spec/system/sessions_spec.rb
+++ b/spec/system/sessions_spec.rb
@@ -4,7 +4,7 @@ require 'webmock/rspec'
 RSpec.describe "Sessions", type: :system do
   before { driven_by(:rack_test) }
 
-    describe 'login' do
+  describe 'login' do
     context 'when user is a guild member' do
       before do
         uid = '12345678890'
@@ -39,6 +39,7 @@ RSpec.describe "Sessions", type: :system do
       it 'can login' do
         visit root_path
         click_on 'Discordでログイン'
+        expect(page).to have_current_path(items_path)
         expect(page).to have_link, 'ログアウト'
       end
     end
@@ -51,8 +52,24 @@ RSpec.describe "Sessions", type: :system do
       it 'fails to login' do
         visit root_path
         click_on 'Discordでログイン'
-        expect(page).to have_button, 'Discordでログイン'
+        expect(page).to have_current_path(root_path)
       end
+    end
+  end
+
+  describe 'logout' do
+    let(:user) { create(:user) }
+
+    before { login(user) }
+
+    it "can logout" do
+      expect(page).to have_current_path(items_path)
+
+      find(".user-menu__trigger").click
+      click_on 'ログアウト'
+
+      expect(page).to have_content 'ログアウトしました'
+      expect(page).to have_current_path(root_path)
     end
   end
 end


### PR DESCRIPTION
## Issue
- #287 
## 概要
- ログアウト時のテストの追加
- ログインキャンセル時のアラートを削除