### PR TITLE
パス名をtransactionからconversationに、ページタイトルを連絡ページ一覧からやり取り一覧へ変更

### DIFF
--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -1,4 +1,4 @@
-class TransactionsController < ApplicationController
+class ConversationsController < ApplicationController
   def index
     @items = Item.includes(:user, :winner, first_image_attachment: :blob, notifications: :notifiable)
                   .where(user_id: current_user.id, status: :sold)

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -22,7 +22,7 @@ class MessagesController < ApplicationController
     @message.user = current_user
 
     if @message.save
-      redirect_to transaction_messages_path(@item), notice: "メッセージを送信しました"
+      redirect_to conversation_messages_path(@item), notice: "メッセージを送信しました"
     else
       @messages = @item.messages.includes(:user).order(:created_at)
       render :index, status: :unprocessable_content
@@ -32,13 +32,13 @@ class MessagesController < ApplicationController
   # DELETE /messages/1
   def destroy
     @message.destroy!
-    redirect_to transaction_messages_path(@item), notice: "コメントを削除しました", status: :see_other
+    redirect_to conversation_messages_path(@item), notice: "コメントを削除しました", status: :see_other
   end
 
   private
 
   def set_item
-    @item = Item.find(params[:transaction_id])
+    @item = Item.find(params[:conversation_id])
   end
 
   # Only allow a list of trusted parameters through.
@@ -60,7 +60,7 @@ class MessagesController < ApplicationController
 
   def require_admin
     unless current_user.admin?
-      redirect_to transaction_messages_path(@item), alert: "削除する権限がありません"
+      redirect_to conversation_messages_path(@item), alert: "削除する権限がありません"
     end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -14,7 +14,7 @@ module ApplicationHelper
     when "listings"
       label, path = "自分の出品一覧へ", listings_path
     when "messages"
-      label, path = "連絡ページへ", transaction_messages_path(item)
+      label, path = "連絡ページへ", conversation_messages_path(item)
     else
       label, path = "販売中一覧へ", items_path
     end
@@ -41,7 +41,7 @@ module ApplicationHelper
     request.fullpath.include?("from=listings")
   end
 
-  def active_transactions_tab?
-    current_page?(transactions_path) || request.fullpath.include?("from=messages")
+  def active_conversations_tab?
+    [ conversations_path, conversation_messages_path ].any? { |path| current_page?(path) } || request.fullpath.include?("from=messages")
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -42,6 +42,6 @@ module ApplicationHelper
   end
 
   def active_conversations_tab?
-    request.fullpath.match?(%r{\A/conversations|from=messages})
+    request.path.start_with?("/conversations") || request.fullpath.include?("from=messages")
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -42,6 +42,6 @@ module ApplicationHelper
   end
 
   def active_conversations_tab?
-    [ conversations_path, conversation_messages_path ].any? { |path| current_page?(path) } || request.fullpath.include?("from=messages")
+    request.fullpath.match?(%r{\A/conversations|from=messages})
   end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -38,18 +38,18 @@ class Notification < ApplicationRecord
       Rails.application.routes.url_helpers.item_path(notifiable.item)
     when Entry
       if notifiable.won?
-        Rails.application.routes.url_helpers.transaction_messages_path(notifiable.item)
+        Rails.application.routes.url_helpers.conversation_messages_path(notifiable.item)
       else
         Rails.application.routes.url_helpers.item_path(notifiable.item)
       end
     when Item
       if notifiable.sold?
-        Rails.application.routes.url_helpers.transaction_messages_path(notifiable)
+        Rails.application.routes.url_helpers.conversation_messages_path(notifiable)
       else
         Rails.application.routes.url_helpers.item_path(notifiable)
       end
     when Message
-      Rails.application.routes.url_helpers.transaction_messages_path(notifiable.item)
+      Rails.application.routes.url_helpers.conversation_messages_path(notifiable.item)
     end
   end
 end

--- a/app/views/conversations/index.html.slim
+++ b/app/views/conversations/index.html.slim
@@ -1,30 +1,30 @@
-- content_for :title, "連絡ページ一覧"
-- content_for :description, "取引ごとの連絡ページへのリンクを一覧で確認できます。出品者と当選者のやり取りにアクセスするためのページです。"
+- content_for :title, "やり取り一覧"
+- content_for :description, "取引ごとのやり取りへのリンクを一覧で確認できます。出品者と当選者のやり取りにアクセスするためのページです。"
 
-h1.page-title.font-bold.text-2xl.mb-6.text-gray-900.text-center 連絡ページ一覧
+h1.page-title.font-bold.text-2xl.mb-6.text-gray-900.text-center やり取り一覧
 - if @items.empty?
   .empty-state.mt-30.mb-30.text-center
-    p.text-xl.text-gray-500 連絡ページはありません
+    p.text-xl.text-gray-500 やり取りはありません
 - else
   = paginate @items
-  .transaction-list.w-full.max-w-2xl.mx-auto.flex.flex-col.gap-3
+  .conversation-list.w-full.max-w-2xl.mx-auto.flex.flex-col.gap-3
     - @items.each do |item|
-      = link_to transaction_messages_path(item), class: "transaction-item-link block group" do
-        div class=["transaction-card bg-white border border-gray-200 rounded-xl shadow-sm p-4 hover:shadow-md transition-shadow",
+      = link_to conversation_messages_path(item), class: "conversation-item-link block group" do
+        div class=["conversation-card bg-white border border-gray-200 rounded-xl shadow-sm p-4 hover:shadow-md transition-shadow",
         "duration-200 flex gap-4 items-center relative"]
-          .transaction-thumbnail.aspect-square.w-20.h-20.flex-shrink-0.rounded-lg.overflow-hidden.bg-gray-100
+          .conversation-thumbnail.aspect-square.w-20.h-20.flex-shrink-0.rounded-lg.overflow-hidden.bg-gray-100
             - if item.images.attached?
               = image_tag item.first_image.variant(resize_to_limit: [ 200, 200 ]).processed,
                 alt: "#{item.title} 1枚目", class: "object-contain w-full h-full"
             - else
               = image_tag "listing-image.png", alt: "商品画像なし", class: "object-contain w-full h-full opacity-30"
-          .transaction-info.flex.flex-col.gap-1.flex-1.min-w-0
-            p.transaction-title.font-semibold.text-gray-900.text-base.line-clamp-1 = item.title
-            .transaction-price.flex.items-baseline.gap-1.5
+          .conversation-info.flex.flex-col.gap-1.flex-1.min-w-0
+            p.conversation-title.font-semibold.text-gray-900.text-base.line-clamp-1 = item.title
+            .conversation-price.flex.items-baseline.gap-1.5
               span.font-bold.text-gray-900 = number_to_currency(item.price)
               - if item.shipping_fee_payer.present?
                 span.text-sm.text-gray-500 = I18n.t("views.item.shipping_fee_label.#{item.shipping_fee_payer}")
-            .transaction-counterpart.flex.flex-wrap.items-center.gap-2.mt-1
+            .conversation-counterpart.flex.flex-wrap.items-center.gap-2.mt-1
               - if item.user == current_user
                 span.text-sm.text-gray-500 購入者
                 = image_tag (item.winner.avatar_url.presence || "default-avatar.png"), alt: "", class: "w-6 h-6 rounded-full"

--- a/app/views/items/_item.html.slim
+++ b/app/views/items/_item.html.slim
@@ -24,7 +24,7 @@
       - else
         .item-price.mt-1.text-sm.text-gray-400 価格未入力
 
-    - if request.path.include?("transactions")
+    - if request.path.include?("conversations")
       .mt-2
         .flex.items-center.gap-2.flex-wrap
           - if current_user == item.user

--- a/app/views/items/show.html.slim
+++ b/app/views/items/show.html.slim
@@ -146,7 +146,7 @@ article.item-show.mt-2.flex.flex-col.md:grid.md:grid-cols-2.md:gap-10.md:items-s
           | 当選者の
           span.font-semibold = @item.winner.name
           | さんに代金の送り先を伝えるなどのやり取りを行ってください。
-        = link_to transaction_messages_path(@item), class: "flex items-center justify-center gap-2 bg-cyan-600 text-white font-bold py-2.5 px-5 rounded-lg \
+        = link_to conversation_messages_path(@item), class: "flex items-center justify-center gap-2 bg-cyan-600 text-white font-bold py-2.5 px-5 rounded-lg \
           hover:bg-cyan-700 transition-colors text-base" do
           svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-4"
             path stroke-linecap="round" stroke-linejoin="round" d="M20.25 8.511c.884.284 1.5 1.128 1.5 2.097v4.286c0 1.136-.847 2.1-1.98
@@ -182,7 +182,7 @@ article.item-show.mt-2.flex.flex-col.md:grid.md:grid-cols-2.md:gap-10.md:items-s
                 | 出品者の
                 span.font-semibold = @item.user.name
                 | さんに商品の配送先を伝えるなどのやり取りを行ってください。
-              = link_to transaction_messages_path(@item), class: "flex items-center justify-center gap-2 bg-cyan-600 text-white font-bold py-2.5 px-5 \
+              = link_to conversation_messages_path(@item), class: "flex items-center justify-center gap-2 bg-cyan-600 text-white font-bold py-2.5 px-5 \
                 rounded-lg hover:bg-cyan-700 transition-colors text-base" do
                 svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-4"
                   path stroke-linecap="round" stroke-linejoin="round" d="M20.25 8.511c.884.284 1.5 1.128 1.5 2.097v4.286c0 1.136-.847 2.1-1.98

--- a/app/views/messages/index.html.slim
+++ b/app/views/messages/index.html.slim
@@ -55,12 +55,12 @@
               = simple_format(message.body)
         - if current_user.admin?
           .flex.mt-1 class=(is_seller ? "justify-end" : "justify-end pr-12")
-            = button_to "削除する", transaction_message_path(@item, message), method: :delete, data: { turbo_confirm: "本当に削除しますか？" },
+            = button_to "削除する", conversation_message_path(@item, message), method: :delete, data: { turbo_confirm: "本当に削除しますか？" },
               class: "cursor-pointer text-xs text-gray-400 underline hover:text-red-400"
 
   / メッセージ入力
   .message-form.mt-8
-    = form_with(url: transaction_messages_path(@item), model: @message) do |form|
+    = form_with(url: conversation_messages_path(@item), model: @message) do |form|
       .flex.items-start.gap-3 class=(current_user == @item.user ? "" : "flex-row-reverse")
         = image_tag (current_user.avatar_url.presence || "default-avatar.png"), alt: "", class: "w-9 h-9 rounded-full flex-shrink-0"
         .flex-1
@@ -74,4 +74,4 @@
             = form.submit "送信する",
             class: "cursor-pointer border border-cyan-600 text-cyan-600 font-semibold px-5 py-2 rounded-lg hover:bg-cyan-50 text-base transition-colors"
 
-= link_to "連絡ページ一覧へ", transactions_path, class: "mt-4 flex items-center justify-center text-sm text-gray-500 hover:text-gray-700 underline"
+= link_to "やり取り一覧へ", conversations_path, class: "mt-4 flex items-center justify-center text-sm text-gray-500 hover:text-gray-700 underline"

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -56,9 +56,8 @@ header.site-header.sticky.top-0.bg-white.z-10.border-b.border-gray-200.shadow-sm
           = link_to listings_path, class: nav_class.call(active_listings_tab?)
             span 自分の
             span 出品
-          = link_to transactions_path, class: nav_class.call(active_transactions_tab?)
-            span 連絡
-            span ページ
+          = link_to conversations_path, class: nav_class.call(active_conversations_tab?)
+            span やり取り
           - if current_user.has_unread_messages?
             - count = current_user.unread_message_items_count
             - display_count = count > 99 ? "99+" : count

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
   end
   resources :entries, only: %i[index]
   resources :watches, only: %i[index]
-  resources :transactions, only: [:index] do
+  resources :conversations, only: [:index] do
     resources :messages, only: %i[index create destroy]
   end
   resources :notifications, only: [:index] do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe ApplicationHelper, type: :helper do
       it "returns link to messages" do
         result = helper.back_link_for_item(item)
         expect(result).to include("連絡ページへ")
-        expect(result).to include(transaction_messages_path(item))
+        expect(result).to include(conversation_messages_path(item))
       end
     end
 
@@ -258,17 +258,17 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
   end
 
-  describe "#active_transactions_tab?" do
-    context "when current page is transactions_path" do
+  describe "#active_conversations_tab?" do
+    context "when current page is conversations_path" do
       before do
         allow(helper).to receive_messages(
           current_page?: true,
-          request: double(fullpath: transactions_path)
+          request: double(fullpath: conversations_path)
         )
       end
 
       it "returns true" do
-        expect(helper.active_transactions_tab?).to be true
+        expect(helper.active_conversations_tab?).to be true
       end
     end
 
@@ -282,7 +282,7 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
 
       it "returns true" do
-        expect(helper.active_transactions_tab?).to be true
+        expect(helper.active_conversations_tab?).to be true
       end
     end
 
@@ -295,7 +295,7 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
 
       it "returns false" do
-        expect(helper.active_transactions_tab?).to be false
+        expect(helper.active_conversations_tab?).to be false
       end
     end
   end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe Notification, type: :model do
         message = create(:message, user: buyer, item: sold_item)
         notification = create(:notification, :for_message, user: seller, notifiable: message)
 
-        expect(notification.link).to eq("/transactions/#{sold_item.id}/messages")
+        expect(notification.link).to eq("/conversations/#{sold_item.id}/messages")
       end
     end
 
@@ -111,7 +111,7 @@ RSpec.describe Notification, type: :model do
       it "returns link to messages" do
         notification = create(:notification, :for_entry, notifiable: entry, user: buyer)
 
-        expect(notification.link).to eq("/transactions/#{sold_item.id}/messages")
+        expect(notification.link).to eq("/conversations/#{sold_item.id}/messages")
       end
     end
 
@@ -129,7 +129,7 @@ RSpec.describe Notification, type: :model do
       it "returns link to message" do
         notification = create(:notification, :for_item, notifiable: sold_item, user: seller)
 
-        expect(notification.link).to eq("/transactions/#{sold_item.id}/messages")
+        expect(notification.link).to eq("/conversations/#{sold_item.id}/messages")
       end
     end
 

--- a/spec/requests/conversations_spec.rb
+++ b/spec/requests/conversations_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
-RSpec.describe "Transactions", type: :request do
+RSpec.describe "Conversations", type: :request do
   let(:user) { create(:user) }
 
   before { login user }
 
   describe "GET /index" do
     it "returns http success" do
-      get transactions_path
+      get conversations_path
       expect(response).to have_http_status(:success)
     end
   end

--- a/spec/requests/messages_spec.rb
+++ b/spec/requests/messages_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "/messages", type: :request do
       it "redirects to items" do
         other_user = create(:user)
         login(other_user)
-        get transaction_messages_path(item)
+        get conversation_messages_path(item)
         expect(response).to redirect_to(items_path)
       end
     end
@@ -20,7 +20,7 @@ RSpec.describe "/messages", type: :request do
         login(buyer)
         create(:entry, :won, item: item, user: buyer)
         create(:message, user: buyer, item: item)
-        get transaction_messages_path(item)
+        get conversation_messages_path(item)
         expect(response).to be_successful
       end
 
@@ -29,7 +29,7 @@ RSpec.describe "/messages", type: :request do
         create_list(:message, 2, user: seller, item: item)
         login(buyer)
         expect(buyer.notifications.pluck(:read)).to all(be false)
-        get transaction_messages_path(item)
+        get conversation_messages_path(item)
         expect(buyer.notifications.reload.pluck(:read)).to all(be true)
       end
     end
@@ -44,14 +44,14 @@ RSpec.describe "/messages", type: :request do
       it "creates a new Message" do
         create(:entry, :won, item: item, user: buyer)
         expect {
-          post transaction_messages_path(item), params: { message: valid_attributes }
+          post conversation_messages_path(item), params: { message: valid_attributes }
         }.to change(Message, :count).by(1)
       end
 
       it "redirects to the message index" do
         create(:entry, :won, item: item, user: buyer)
-        post transaction_messages_path(item), params: { message: valid_attributes }
-        expect(response).to redirect_to(transaction_messages_path(item))
+        post conversation_messages_path(item), params: { message: valid_attributes }
+        expect(response).to redirect_to(conversation_messages_path(item))
       end
     end
 
@@ -61,13 +61,13 @@ RSpec.describe "/messages", type: :request do
       it "does not create a new Message" do
         create(:entry, :won, item: item, user: buyer)
         expect {
-          post transaction_messages_path(item), params: { message: invalid_attributes }
+          post conversation_messages_path(item), params: { message: invalid_attributes }
         }.not_to change(Message, :count)
       end
 
       it "renders a response with 422 status (i.e. to display the 'new' template)" do
         create(:entry, :won, item: item, user: buyer)
-        post transaction_messages_path(item), params: { message: invalid_attributes }
+        post conversation_messages_path(item), params: { message: invalid_attributes }
         expect(response).to have_http_status(:unprocessable_content)
       end
     end
@@ -80,9 +80,9 @@ RSpec.describe "/messages", type: :request do
         login(buyer)
         message = create(:message, user: buyer, item: item)
         expect {
-          delete transaction_message_url(item, message)
+          delete conversation_message_url(item, message)
         }.not_to change(Message, :count)
-        expect(response).to redirect_to(transaction_messages_url(item))
+        expect(response).to redirect_to(conversation_messages_url(item))
       end
     end
 
@@ -95,15 +95,15 @@ RSpec.describe "/messages", type: :request do
         message = create(:message, user: buyer, item: item)
 
         expect {
-          delete transaction_message_url(item, message)
+          delete conversation_message_url(item, message)
         }.to change(Message, :count).by(-1)
       end
 
       it "redirects to item" do
         message = create(:message, user: buyer, item: item)
 
-        delete transaction_message_url(item, message)
-        expect(response).to redirect_to(transaction_messages_url(item))
+        delete conversation_message_url(item, message)
+        expect(response).to redirect_to(conversation_messages_url(item))
       end
     end
   end

--- a/spec/system/messages_spec.rb
+++ b/spec/system/messages_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Messages", type: :system do
         login(buyer)
         expect(page).to have_current_path(items_path)
 
-        visit transaction_messages_path(item)
+        visit conversation_messages_path(item)
 
         fill_in "message_body", with: "こんにちは"
         click_on "送信する"
@@ -32,7 +32,7 @@ RSpec.describe "Messages", type: :system do
         login(other_user)
         expect(page).to have_current_path(items_path)
 
-        visit transaction_messages_path(item)
+        visit conversation_messages_path(item)
 
         expect(page).to have_current_path(items_path)
         expect(page).to have_content("この連絡ページを閲覧する権限がありません")
@@ -46,7 +46,7 @@ RSpec.describe "Messages", type: :system do
         login(seller)
         expect(page).to have_current_path(items_path)
 
-        visit transaction_messages_path(item)
+        visit conversation_messages_path(item)
 
         fill_in "message_body", with: "\n"
         click_on "送信する"
@@ -65,7 +65,7 @@ RSpec.describe "Messages", type: :system do
       create(:message, user: seller, item: item, body: "大丈夫です")
       expect(page).to have_current_path(items_path)
 
-      visit transaction_messages_path(item)
+      visit conversation_messages_path(item)
 
       within(find(".message", text: "大丈夫です")) do
         accept_confirm do


### PR DESCRIPTION
## Issue
- #277 

## 概要
- `/transactions`を`/conversations`に変更し、メッセージ一覧ページ（連絡ページ）が`/conversations/id/messages`というURLになるように変更
- 「連絡ページ一覧」というタイトルを「やり取り一覧」に変更
- 連絡ページにいる時グローバルナビの強調表示がない不具合を修正