### PR TITLE
やり取りタブには数字なしのマークがつくよう変更

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,12 +42,4 @@ class User < ApplicationRecord
   def has_unread_messages?
     notifications.unread.where(notifiable_type: "Message").exists?
   end
-
-  def unread_message_items_count
-    notifications.unread
-                  .where(notifiable_type: "Message")
-                  .joins("INNER JOIN messages ON notifications.notifiable_id = messages.id")
-                  .distinct
-                  .count("messages.item_id")
-  end
 end

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -59,10 +59,7 @@ header.site-header.sticky.top-0.bg-white.z-10.border-b.border-gray-200.shadow-sm
           = link_to conversations_path, class: nav_class.call(active_conversations_tab?)
             span やり取り
           - if current_user.has_unread_messages?
-            - count = current_user.unread_message_items_count
-            - display_count = count > 99 ? "99+" : count
-            span#message-count.absolute.top-0.right-0.min-w-5.px-1.bg-red-500.text-white.text-xs.font-bold.rounded-full.flex.items-center.justify-center
-              = display_count
+            .message-notification.absolute.top-0.right-0.bg-red-500.rounded-full style="width: 15px; height: 15px;"
   - else
     .flex.justify-between.items-center.px-6.py-3
       = link_to root_path do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -133,29 +133,4 @@ RSpec.describe User, type: :model do
       end
     end
   end
-
-  describe "#unread_message_items_count" do
-    let(:user) { create(:user) }
-    let(:item) { create(:item) }
-    let(:other_item) { create(:item) }
-
-    before do
-      message1a = create(:message, item: item)
-      message1b = create(:message, item: item)
-      create(:notification, user: user, notifiable: message1a)
-      create(:notification, user: user, notifiable: message1b)
-
-      message2 = create(:message, item: other_item)
-      create(:notification, user: user, notifiable: message2)
-
-      read_message = create(:message, item: item)
-      create(:notification, user: user, notifiable: read_message)
-
-      create(:notification, :for_item, user: user)
-    end
-
-    it "returns item count with unread messages" do
-      expect(user.unread_message_items_count).to eq(2)
-    end
-  end
 end

--- a/spec/system/notifications_spec.rb
+++ b/spec/system/notifications_spec.rb
@@ -121,17 +121,4 @@ RSpec.describe "Notifications", type: :system do
       expect(page).to have_content("「#{sold_item.title}」の購入者が決まりました。")
     end
   end
-
-  describe "message notification count" do
-    context "when over 99 notifications exists" do
-      it "shows 99+ count on notification icon" do
-        create_list(:notification, 100, :for_message, user: user)
-        expect(page).to have_current_path(items_path)
-
-        visit items_path
-
-        expect(page).to have_selector("#message-count", text: "99+")
-      end
-    end
-  end
 end


### PR DESCRIPTION
## Issue
- #306 
## 概要
メッセージが届いている時やり取りタブには数字なしの丸が通知の印としてつくよう変更