### PR TITLE
scopeを使わずにパラメータに応じて情報を表示するよう修正

### DIFF
--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -4,12 +4,12 @@ class EntriesController < ApplicationController
   PER_PAGE = 12
 
   def index
-    @entries = current_user.entries
-                            .by_target(params[:status])
-                            .order("items.entry_deadline_at DESC, entries.created_at DESC")
-                            .includes(item: [ :user, :winner, first_image_attachment: { blob: :variant_records } ])
-                            .page(params[:page])
-                            .per(PER_PAGE)
+    entry_scope = current_user.entries
+    entry_scope = entry_scope.where(status: params[:status]) if params[:status].present?
+    @entries = entry_scope.order("items.entry_deadline_at DESC, entries.created_at DESC")
+                          .includes(item: [ :user, :winner, first_image_attachment: { blob: :variant_records } ])
+                          .page(params[:page])
+                          .per(PER_PAGE)
   end
 
   # POST /entries

--- a/app/controllers/items/listings_controller.rb
+++ b/app/controllers/items/listings_controller.rb
@@ -2,11 +2,11 @@ class Items::ListingsController < ApplicationController
   PER_PAGE = 16
 
   def index
-    @listings = current_user.items
-                            .by_target(params[:status])
-                            .order(entry_deadline_at: :desc, updated_at: :desc)
-                            .includes(:winner, first_image_attachment: { blob: :variant_records })
-                            .page(params[:page])
-                            .per(PER_PAGE)
+    item_scope = current_user.items
+    item_scope = item_scope.where(status: params[:status]) if params[:status].present?
+    @listings = item_scope.order(entry_deadline_at: :desc, updated_at: :desc)
+                          .includes(:winner, first_image_attachment: { blob: :variant_records })
+                          .page(params[:page])
+                          .per(PER_PAGE)
   end
 end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -4,9 +4,10 @@ class NotificationsController < ApplicationController
   def index
     notification_scope = current_user.notifications
     notification_scope = notification_scope.unread if params[:status] == "unread"
-    @notifications = notification_scope.order(created_at: :desc)
-                                        .preload(notifiable: [ :user, { item: [ :user, :winner ] } ])
-                                        .page(params[:page])
-                                        .per(PER_PAGE)
+    @notifications = notification_scope
+                      .order(created_at: :desc)
+                      .preload(notifiable: [ :user, { item: [ :user, :winner ] } ])
+                      .page(params[:page])
+                      .per(PER_PAGE)
   end
 end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -2,11 +2,15 @@ class NotificationsController < ApplicationController
   PER_PAGE = 20
 
   def index
-    @notifications = current_user.notifications
-                                  .by_target(params[:status])
-                                  .order(created_at: :desc)
-                                  .preload(notifiable: [ :user, { item: [ :user, :winner ] } ])
-                                  .page(params[:page])
-                                  .per(PER_PAGE)
+    notification_scope = current_user.notifications
+    if params[:status] == "unread"
+      notification_scope = notification_scope.unread
+    elsif params[:status].present?
+      notification_scope = notification_scope.none
+    end
+    @notifications = notification_scope.order(created_at: :desc)
+                                        .preload(notifiable: [ :user, { item: [ :user, :winner ] } ])
+                                        .page(params[:page])
+                                        .per(PER_PAGE)
   end
 end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -3,11 +3,7 @@ class NotificationsController < ApplicationController
 
   def index
     notification_scope = current_user.notifications
-    if params[:status] == "unread"
-      notification_scope = notification_scope.unread
-    elsif params[:status].present?
-      notification_scope = notification_scope.none
-    end
+    notification_scope = notification_scope.unread if params[:status] == "unread"
     @notifications = notification_scope.order(created_at: :desc)
                                         .preload(notifiable: [ :user, { item: [ :user, :winner ] } ])
                                         .page(params[:page])

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -11,14 +11,6 @@ class Entry < ApplicationRecord
   validate :cannot_apply_for_expired_item, on: :create
   validate :cannot_apply_for_closed_item, on: :create
 
-  scope :by_target, ->(target) {
-  if target.present? && statuses.key?(target)
-    where(status: target)
-  else
-    all
-  end
-  }
-
   private
 
   def cannot_apply_for_own_item

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -41,13 +41,6 @@ class Item < ApplicationRecord
   scope :not_expired, -> { where(entry_deadline_at: Time.current.beginning_of_day..) }
   scope :expired, -> { where.not(id: not_expired).where(status: :published) }
   scope :commentable, -> { where.not(status: :draft) }
-  scope :by_target, ->(target) {
-  if target.present? && statuses.key?(target)
-    where(status: target)
-  else
-    all
-  end
-  }
 
   EDITABLE_FIELDS = [ :title, :description, :price, :shipping_fee_payer, :payment_method, :entry_deadline_at, images: [] ].freeze
 

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -3,13 +3,6 @@ class Notification < ApplicationRecord
   belongs_to :notifiable, polymorphic: true
 
   scope :unread, -> { where(read: false) }
-  scope :by_target, ->(target) {
-  if target == "unread"
-    where(read: false)
-  else
-    all
-  end
-  }
 
   def message
     case notifiable

--- a/spec/models/entry_spec.rb
+++ b/spec/models/entry_spec.rb
@@ -21,37 +21,6 @@ RSpec.describe Entry, type: :model do
     end
   end
 
-  describe ".by_target" do
-    let(:applier) { create(:user) }
-    let!(:applied_entry) { create(:entry, user: applier) }
-    let!(:won_entry) { create(:entry, :won, user: applier) }
-    let!(:lost_entry) { create(:entry, :lost, user: applier) }
-
-    context "when target is applied" do
-      it "returns applied entries" do
-        expect(applier.entries.by_target("applied")).to contain_exactly(applied_entry)
-      end
-    end
-
-    context "when target is won" do
-      it "returns won entries" do
-        expect(applier.entries.by_target("won")).to contain_exactly(won_entry)
-      end
-    end
-
-    context "when target is lost" do
-      it "returns lost entries" do
-        expect(applier.entries.by_target("lost")).to contain_exactly(lost_entry)
-      end
-    end
-
-    context "when target is invalid" do
-      it "returns all entries" do
-        expect(applier.entries.by_target("invalid_status")).to contain_exactly(applied_entry, won_entry, lost_entry)
-      end
-    end
-  end
-
   describe "#cannot_apply_for_own_item" do
     let(:item) { create(:item, :published, user: seller) }
     let(:entry) { build(:entry, item: item, user: seller) }

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -82,43 +82,6 @@ RSpec.describe Item, type: :model do
     end
   end
 
-  describe ".by_target" do
-    let!(:published_item) { create(:item, :published) }
-    let!(:closed_item) { create(:item, :closed) }
-    let!(:sold_item) { create(:item, :sold) }
-    let!(:draft_item) { create(:item) }
-
-    context "when target is published" do
-      it "returns published item" do
-        expect(Item.by_target("published")).to contain_exactly(published_item)
-      end
-    end
-
-    context "when target is closed" do
-      it "returns closed item" do
-        expect(Item.by_target("closed")).to contain_exactly(closed_item)
-      end
-    end
-
-    context "when target is sold" do
-      it "returns sold item" do
-        expect(Item.by_target("sold")).to contain_exactly(sold_item)
-      end
-    end
-
-    context "when target is draft" do
-      it "returns draft item" do
-        expect(Item.by_target("draft")).to contain_exactly(draft_item)
-      end
-    end
-
-    context "when target is invalid" do
-      it "returns all items" do
-        expect(Item.by_target("invalid")).to contain_exactly(published_item, closed_item, sold_item, draft_item)
-      end
-    end
-  end
-
   describe "#other_user_for" do
     let(:seller) { create(:user) }
     let(:item) { create(:item, :sold, user: seller) }

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -13,23 +13,6 @@ RSpec.describe Notification, type: :model do
     end
   end
 
-  describe ".by_target" do
-    let!(:unread_notification) { create(:notification, :for_item, user: user) }
-    let!(:read_notification) { create(:notification, :for_item, :read, user: user) }
-
-    context "when target is unread" do
-      it "returns unread notifications" do
-        expect(Notification.by_target("unread")).to contain_exactly(unread_notification)
-      end
-    end
-
-    context "when target is invalid" do
-      it "returns all notifications" do
-        expect(Notification.by_target("invalid_status")).to contain_exactly(unread_notification, read_notification)
-      end
-    end
-  end
-
   describe "#message" do
     context "when notifiable is message" do
       let(:notification) { create(:notification, :for_message, user: user) }

--- a/spec/requests/entries_spec.rb
+++ b/spec/requests/entries_spec.rb
@@ -71,15 +71,17 @@ RSpec.describe "/entries", type: :request do
     end
 
     context "when filtering by invalid status" do
-      let!(:applied_entry) { create(:entry, user: user) }
-      let!(:won_entry) { create(:entry, :won, user: user) }
-      let!(:lost_entry) { create(:entry, :lost, user: user) }
+      before do
+        create(:entry, user: user)
+        create(:entry, :won, user: user)
+        create(:entry, :lost, user: user)
+      end
 
-      it "returns all entries" do
+      it "returns no entries" do
         get entries_path(status: "invalid_status")
 
         expect(response).to have_http_status(:success)
-        expect(response.body).to include(applied_entry.item.title, won_entry.item.title, lost_entry.item.title)
+        expect(response.body).to include("該当する商品はありません")
       end
     end
   end

--- a/spec/requests/items/listings_spec.rb
+++ b/spec/requests/items/listings_spec.rb
@@ -75,16 +75,18 @@ RSpec.describe "Items::Listings", type: :request do
     end
 
     context "when filtering by invalid status" do
-      let!(:draft_item) { create(:item, user: user) }
-      let!(:published_item) { create(:item, :published, user: user) }
-      let!(:sold_item) { create(:item, :sold, user: user) }
-      let!(:closed_item) { create(:item, :closed, user: user) }
+      before do
+        create(:item, user: user)
+        create(:item, :published, user: user)
+        create(:item, :sold, user: user)
+        create(:item, :closed, user: user)
+      end
 
-      it "returns all listings" do
+      it "returns no listings" do
         get listings_path(status: "invalid")
 
         expect(response).to have_http_status(:success)
-        expect(response.body).to include(draft_item.title, published_item.title, sold_item.title, closed_item.title)
+        expect(response.body).to include("該当する商品はありません")
       end
     end
   end

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -44,16 +44,14 @@ RSpec.describe "Notifications", type: :request do
     end
 
     context "when filtering by invalid status" do
-      before do
-        create(:notification, :for_item, user: user)
-        create(:notification, :for_item, :read, user: user)
-      end
+      let!(:unread_notification) { create(:notification, :for_item, user: user) }
+      let!(:read_notification) { create(:notification, :for_item, :read, user: user) }
 
-      it "returns no notifications" do
+      it "returns all notifications" do
         get notifications_path(status: "invalid_status")
 
         expect(response).to have_http_status(:success)
-        expect(response.body).to include("通知はありません")
+        expect(response.body).to include(unread_notification.message, read_notification.message)
       end
     end
   end

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -44,14 +44,16 @@ RSpec.describe "Notifications", type: :request do
     end
 
     context "when filtering by invalid status" do
-      let!(:unread_notification) { create(:notification, :for_item, user: user) }
-      let!(:read_notification) { create(:notification, :for_item, :read, user: user) }
+      before do
+        create(:notification, :for_item, user: user)
+        create(:notification, :for_item, :read, user: user)
+      end
 
-      it "returns all notifications" do
+      it "returns no notifications" do
         get notifications_path(status: "invalid_status")
 
         expect(response).to have_http_status(:success)
-        expect(response.body).to include(unread_notification.message, read_notification.message)
+        expect(response.body).to include("通知はありません")
       end
     end
   end


### PR DESCRIPTION
## Issue
- #332 
## 概要
パラメータに応じて情報を絞り込む処理をscopeではなくコントローラで行い、不正なパラメータに対して情報を表示しないよう修正した。合わせてモデルテストの削除・リクエストテストの修正を行なった。