### PR TITLE
画像添付のバリデーションをモデルとJSで連動するよう修正

### DIFF
--- a/app/javascript/controllers/image_preview_controller.js
+++ b/app/javascript/controllers/image_preview_controller.js
@@ -184,11 +184,11 @@ export default class extends Controller {
 
   validateFileTypes(filesOrFile, e) {
     const files = Array.isArray(filesOrFile) ? filesOrFile : [filesOrFile];
-    const typeNames = this.allowedTypesValue.map((type) => type.split('/')[1].toUpperCase());
-    const joinedTypes = typeNames.join('または');
 
     if (files.some((file) => !this.allowedTypesValue.includes(file.type))) {
       e.stopImmediatePropagation();
+      const typeNames = this.allowedTypesValue.map((type) => type.split('/')[1].toUpperCase());
+      const joinedTypes = typeNames.join('または');
       alert(`${joinedTypes}形式のみアップロード可能です`);
       e.target.value = '';
       return false;

--- a/app/javascript/controllers/image_preview_controller.js
+++ b/app/javascript/controllers/image_preview_controller.js
@@ -6,7 +6,7 @@ export default class extends Controller {
   static values = {
     maxCount: Number,
     allowedTypes: Array,
-    maxSize: Number,
+    maxSizeMegabytes: Number,
   };
 
   connect() {
@@ -198,11 +198,11 @@ export default class extends Controller {
 
   validateMaxSize(filesOrFile, e) {
     const files = Array.isArray(filesOrFile) ? filesOrFile : [filesOrFile];
-    const maxSizeBytes = this.maxSizeValue * 1024 * 1024;
+    const maxSizeMegabytes = this.maxSizeMegabytesValue * 1024 * 1024;
 
-    if (files.some((file) => file.size > maxSizeBytes)) {
+    if (files.some((file) => file.size > maxSizeMegabytes)) {
       e.stopImmediatePropagation();
-      alert(`${this.maxSizeValue}MBまでのファイルのみアップロードできます`);
+      alert(`${this.maxSizeMegabytesValue}MBまでのファイルのみアップロードできます`);
       e.target.value = '';
       return false;
     }

--- a/app/javascript/controllers/image_preview_controller.js
+++ b/app/javascript/controllers/image_preview_controller.js
@@ -4,6 +4,8 @@ import { Controller } from '@hotwired/stimulus';
 export default class extends Controller {
   static targets = ['input', 'preview', 'savedPreview', 'extraContainer', 'labelText', 'multipleContainer'];
   static values = {
+    maxCount: Number,
+    allowedTypes: Array,
     maxSize: Number,
   };
 
@@ -53,25 +55,12 @@ export default class extends Controller {
   }
 
   previewMultipleImages(e) {
-    if (!this.checkTotalFiles(e)) return;
+    if (!this.validateTotalFiles(e)) return;
 
     const files = Array.from(e.target.files);
 
-    const ALLOWED_TYPES = ['image/png', 'image/jpeg'];
-    if (files.some((file) => !ALLOWED_TYPES.includes(file.type))) {
-      e.stopImmediatePropagation();
-      alert('PNGまたはJPEG形式のみアップロード可能です');
-      e.target.value = '';
-      return;
-    }
-
-    const MAX_SIZE = this.maxSizeValue * 1024 * 1024;
-    if (files.some((file) => file.size > MAX_SIZE)) {
-      e.stopImmediatePropagation();
-      alert(`${this.maxSizeValue}MBまでのファイルのみアップロードできます`);
-      e.target.value = '';
-      return;
-    }
+    if (!this.validateFileTypes(files, e)) return;
+    if (!this.validateMaxSize(files, e)) return;
 
     this.element.querySelectorAll('.js-multiple-preview').forEach((element) => element.remove());
 
@@ -117,25 +106,12 @@ export default class extends Controller {
   }
 
   previewSingleImage(e) {
-    if (!this.checkTotalFiles(e)) return;
+    if (!this.validateTotalFiles(e)) return;
 
     const file = e.target.files[0];
 
-    const ALLOWED_TYPES = ['image/png', 'image/jpeg'];
-    if (file && !ALLOWED_TYPES.includes(file.type)) {
-      e.stopImmediatePropagation();
-      alert('PNGまたはJPEG形式のみアップロード可能です');
-      e.target.value = '';
-      return;
-    }
-
-    const MAX_SIZE = this.maxSizeValue * 1024 * 1024;
-    if (file && file.size > MAX_SIZE) {
-      e.stopImmediatePropagation();
-      alert(`${this.maxSizeValue}MBまでのファイルのみアップロードできます`);
-      e.target.value = '';
-      return;
-    }
+    if (!this.validateFileTypes(file, e)) return;
+    if (!this.validateMaxSize(file, e)) return;
 
     const label = e.target.closest('label');
     const container = label.querySelector('[data-image-preview-target="container"]');
@@ -192,15 +168,41 @@ export default class extends Controller {
     });
   }
 
-  checkTotalFiles(e) {
-    const MAX_FILES = 5;
-
+  validateTotalFiles(e) {
     const existingCount = this.savedPreviewTargets.length;
     const newFilesCount = e.target.files.length;
+    const maxCount = this.maxCountValue;
 
-    if (existingCount + newFilesCount > MAX_FILES) {
+    if (existingCount + newFilesCount > maxCount) {
       e.stopImmediatePropagation();
-      alert(`画像は${MAX_FILES}枚までしか登録できません`);
+      alert(`画像は${maxCount}枚までしか登録できません`);
+      e.target.value = '';
+      return false;
+    }
+    return true;
+  }
+
+  validateFileTypes(filesOrFile, e) {
+    const files = Array.isArray(filesOrFile) ? filesOrFile : [filesOrFile];
+    const typeNames = this.allowedTypesValue.map((type) => type.split('/')[1].toUpperCase());
+    const joinedTypes = typeNames.join('または');
+
+    if (files.some((file) => !this.allowedTypesValue.includes(file.type))) {
+      e.stopImmediatePropagation();
+      alert(`${joinedTypes}形式のみアップロード可能です`);
+      e.target.value = '';
+      return false;
+    }
+    return true;
+  }
+
+  validateMaxSize(filesOrFile, e) {
+    const files = Array.isArray(filesOrFile) ? filesOrFile : [filesOrFile];
+    const maxSizeBytes = this.maxSizeValue * 1024 * 1024;
+
+    if (files.some((file) => file.size > maxSizeBytes)) {
+      e.stopImmediatePropagation();
+      alert(`${this.maxSizeValue}MBまでのファイルのみアップロードできます`);
       e.target.value = '';
       return false;
     }

--- a/app/javascript/controllers/image_preview_controller.js
+++ b/app/javascript/controllers/image_preview_controller.js
@@ -3,6 +3,9 @@ import { Controller } from '@hotwired/stimulus';
 // Connects to data-controller="image-preview"
 export default class extends Controller {
   static targets = ['input', 'preview', 'savedPreview', 'extraContainer', 'labelText', 'multipleContainer'];
+  static values = {
+    maxSize: Number,
+  };
 
   connect() {
     this.updateExtraSlots();
@@ -62,10 +65,10 @@ export default class extends Controller {
       return;
     }
 
-    const MAX_SIZE = 5 * 1024 * 1024;
+    const MAX_SIZE = this.maxSizeValue * 1024 * 1024;
     if (files.some((file) => file.size > MAX_SIZE)) {
-      e.stopImmediatePropagation;
-      alert('5MBまでのファイルのみアップロードできます');
+      e.stopImmediatePropagation();
+      alert(`${this.maxSizeValue}MBまでのファイルのみアップロードできます`);
       e.target.value = '';
       return;
     }
@@ -126,10 +129,10 @@ export default class extends Controller {
       return;
     }
 
-    const MAX_SIZE = 5 * 1024 * 1024;
+    const MAX_SIZE = this.maxSizeValue * 1024 * 1024;
     if (file && file.size > MAX_SIZE) {
-      e.stopImmediatePropagation;
-      alert('5MBまでのファイルのみアップロードできます');
+      e.stopImmediatePropagation();
+      alert(`${this.maxSizeValue}MBまでのファイルのみアップロードできます`);
       e.target.value = '';
       return;
     }

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -22,9 +22,9 @@ class Item < ApplicationRecord
 
   MAX_COUNT = 5
   ALLOWED_TYPES = %w[ image/png image/jpeg ].freeze
-  MAX_SIZE = 5
+  MAX_SIZE_MB = 5
 
-  validates :images, limit: { max: MAX_COUNT }, content_type: ALLOWED_TYPES, size: { less_than: MAX_SIZE.megabytes }
+  validates :images, limit: { max: MAX_COUNT }, content_type: ALLOWED_TYPES, size: { less_than: MAX_SIZE_MB.megabytes }
 
   validates :title, length: { maximum: 255 }, presence: true, on: :publish
   validates :price, presence: true, on: :publish

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -20,9 +20,11 @@ class Item < ApplicationRecord
 
   attr_accessor :title_append, :description_append, :payment_method_append
 
+  MAX_COUNT = 5
+  ALLOWED_TYPES = %w[ image/png image/jpeg ].freeze
   MAX_SIZE = 5
 
-  validates :images, limit: { max: 5 }, content_type: [ "image/png", "image/jpeg" ], size: { less_than: MAX_SIZE.megabytes }
+  validates :images, limit: { max: MAX_COUNT }, content_type: ALLOWED_TYPES, size: { less_than: MAX_SIZE.megabytes }
 
   validates :title, length: { maximum: 255 }, presence: true, on: :publish
   validates :price, presence: true, on: :publish

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -20,7 +20,9 @@ class Item < ApplicationRecord
 
   attr_accessor :title_append, :description_append, :payment_method_append
 
-  validates :images, limit: { max: 5 }, content_type: [ "image/png", "image/jpeg" ], size: { less_than: 5.megabytes }
+  MAX_SIZE = 5
+
+  validates :images, limit: { max: 5 }, content_type: [ "image/png", "image/jpeg" ], size: { less_than: MAX_SIZE.megabytes }
 
   validates :title, length: { maximum: 255 }, presence: true, on: :publish
   validates :price, presence: true, on: :publish

--- a/app/views/items/_form.html.slim
+++ b/app/views/items/_form.html.slim
@@ -15,7 +15,10 @@
       = form.text_field :title_append,
       class: "w-full px-3 py-2 bg-white border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:border-transparent"
 
-  div data-controller="image-preview" data-image-preview-max-size-value="#{Item::MAX_SIZE}"
+  div[data-controller="image-preview"
+  data={ "image-preview-max-count-value": Item::MAX_COUNT,
+          "image-preview-allowed-types-value": Item::ALLOWED_TYPES.to_json,
+          "image-preview-max-size-value": Item::MAX_SIZE }]
     .flex.items-center.gap-x-2.mb-1
       h2.font-semibold.text-sm.text-gray-700.block 商品画像
       span.text-xs.text-gray-500 最大5枚

--- a/app/views/items/_form.html.slim
+++ b/app/views/items/_form.html.slim
@@ -15,7 +15,7 @@
       = form.text_field :title_append,
       class: "w-full px-3 py-2 bg-white border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:border-transparent"
 
-  div data-controller="image-preview"
+  div data-controller="image-preview" data-image-preview-max-size-value="#{Item::MAX_SIZE}"
     .flex.items-center.gap-x-2.mb-1
       h2.font-semibold.text-sm.text-gray-700.block 商品画像
       span.text-xs.text-gray-500 最大5枚

--- a/app/views/items/_form.html.slim
+++ b/app/views/items/_form.html.slim
@@ -18,7 +18,7 @@
   div[data-controller="image-preview"
   data={ "image-preview-max-count-value": Item::MAX_COUNT,
           "image-preview-allowed-types-value": Item::ALLOWED_TYPES.to_json,
-          "image-preview-max-size-value": Item::MAX_SIZE }]
+          "image-preview-max-size-megabytes-value": Item::MAX_SIZE_MB }]
     .flex.items-center.gap-x-2.mb-1
       h2.font-semibold.text-sm.text-gray-700.block 商品画像
       span.text-xs.text-gray-500 最大5枚


### PR DESCRIPTION
## Issue
- #335
## 概要
画像の枚数、形式、サイズのバリデーションをモデルに定義しJS（Stimulus）はそれを使うように修正した。合わせて画像を一つずつ選択した場合と複数まとめて選択した場合でアップロードを中止する処理を共通化した。