### PR TITLE
メッセージ受信者を指定するメソッドをMessageモデルに移行

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,6 +1,7 @@
 class MessagesController < ApplicationController
   before_action :set_item
   before_action :authorize_user
+  before_action :validate_message_sender, only: %i[create]
   before_action :require_admin, only: %i[destroy]
 
   # GET /messages
@@ -46,11 +47,13 @@ class MessagesController < ApplicationController
   end
 
   def authorize_user
-    return if @item.user_id == current_user.id
-    return if @item.winner == current_user
-    return if current_user.admin?
+    return if @item.participant?(current_user) || current_user.admin?
 
     redirect_to @item, alert: "この連絡ページを閲覧する権限がありません"
+  end
+
+  def validate_message_sender
+    redirect_to conversation_messages_path(@item), alert: "出品者・購入者以外はメッセージを送信できません" unless @item.participant?(current_user)
   end
 
   def require_admin

--- a/app/jobs/notify_message_created_job.rb
+++ b/app/jobs/notify_message_created_job.rb
@@ -10,7 +10,7 @@ class NotifyMessageCreatedJob < ApplicationJob
         :first_image
       ],
     ).find(message_id)
-    recipient = message.item.other_user_for(message.user)
+    recipient = message.recipient
     return if recipient.nil?
     Notification.create!(user: recipient, notifiable: message)
     DiscordWebhook.new.notify_new_message(recipient, message.item)

--- a/app/jobs/notify_message_created_job.rb
+++ b/app/jobs/notify_message_created_job.rb
@@ -12,7 +12,7 @@ class NotifyMessageCreatedJob < ApplicationJob
     ).find(message_id)
     recipient = message.recipient
     return if recipient.nil?
-    Notification.create!(user: recipient, notifiable: message)
+    recipient.notifications.create!(notifiable: message)
     DiscordWebhook.new.notify_new_message(recipient, message.item)
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -64,9 +64,7 @@ class Item < ApplicationRecord
   end
 
   def participant?(user)
-    return false if user.nil?
-
-    user.id == self.user_id || user.id == won_entry&.user_id
+    user && user.id.in?([ user_id, won_entry&.user_id ])
   end
 
   private

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -48,13 +48,6 @@ class Item < ApplicationRecord
 
   EDITABLE_FIELDS = [ :title, :description, :price, :shipping_fee_payer, :payment_method, :entry_deadline_at, images: [] ].freeze
 
-  def other_user_for(current_user)
-    if current_user.admin? && [ user, winner ].exclude?(current_user)
-      return nil
-    end
-    user == current_user ? winner : user
-  end
-
   def close!(reason: :user_action)
     update!(status: :closed)
     NotifyItemClosedJob.perform_later(id, reason: reason)

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -63,6 +63,12 @@ class Item < ApplicationRecord
     !draft?
   end
 
+  def participant?(user)
+    return false if user.nil?
+
+    user.id == self.user_id || user.id == won_entry&.user_id
+  end
+
   private
 
   def deadline_must_be_today_or_later

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -7,6 +7,13 @@ class Message < ApplicationRecord
 
   after_create_commit :create_notifications
 
+  def recipient
+    if user.admin? && [ item.user, item.winner ].exclude?(user)
+      return nil
+    end
+    user == item.user ? item.winner : item.user
+  end
+
   private
 
   def create_notifications

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -8,9 +8,7 @@ class Message < ApplicationRecord
   after_create_commit :create_notifications
 
   def recipient
-    if user.admin? && [ item.user, item.winner ].exclude?(user)
-      return nil
-    end
+    return if user.admin? && [ item.user, item.winner ].exclude?(user)
     user == item.user ? item.winner : item.user
   end
 

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -8,7 +8,6 @@ class Message < ApplicationRecord
   after_create_commit :create_notifications
 
   def recipient
-    return if user.admin? && [ item.user, item.winner ].exclude?(user)
     user == item.user ? item.winner : item.user
   end
 

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -21,7 +21,7 @@ class Notification < ApplicationRecord
         "「#{notifiable.title}」は当選者なしで公開終了しました。"
       end
     when Message
-      "#{notifiable.item.other_user_for(user).name}さんから「#{notifiable.item.title}」についてメッセージが届きました。"
+      "#{notifiable.user.name}さんから「#{notifiable.item.title}」についてメッセージが届きました。"
     end
   end
 

--- a/app/views/messages/index.html.slim
+++ b/app/views/messages/index.html.slim
@@ -59,20 +59,21 @@
               class: "cursor-pointer text-xs text-gray-400 underline hover:text-red-400"
 
   / メッセージ入力
-  .message-form.mt-8
-    - message = @message || @item.messages.build
-    = form_with(url: conversation_messages_path(@item), model: message) do |form|
-      .flex.items-start.gap-3 class=(current_user == @item.user ? "" : "flex-row-reverse")
-        = image_tag (current_user.avatar_url.presence || "default-avatar.png"), alt: "", class: "w-9 h-9 rounded-full flex-shrink-0"
-        .flex-1
-          - placeholder = current_user == @item.user ? "代金の支払い先など必要な情報を入力してください" : "住所、氏名、電話番号など、配送に必要な情報を入力してください"
-          = form.textarea :body,
-            class: "w-full rounded-xl p-3 min-h-24 border border-gray-200 focus:outline-none focus:border-cyan-400 field-sizing-content text-base bg-white",
-            placeholder: placeholder,
-            required: true
-          = render "shared/error_messages", model: form.object, attribute: :body
-          .flex.justify-end.mt-2
-            = form.submit "送信する",
-            class: "cursor-pointer border border-cyan-600 text-cyan-600 font-semibold px-5 py-2 rounded-lg hover:bg-cyan-50 text-base transition-colors"
+  - if @item.participant?(current_user)
+    .message-form.mt-8
+      - message = @message || @item.messages.build
+      = form_with(url: conversation_messages_path(@item), model: message) do |form|
+        .flex.items-start.gap-3 class=(current_user == @item.user ? "" : "flex-row-reverse")
+          = image_tag (current_user.avatar_url.presence || "default-avatar.png"), alt: "", class: "w-9 h-9 rounded-full flex-shrink-0"
+          .flex-1
+            - placeholder = current_user == @item.user ? "代金の支払い先など必要な情報を入力してください" : "住所、氏名、電話番号など、配送に必要な情報を入力してください"
+            = form.textarea :body,
+              class: "w-full rounded-xl p-3 min-h-24 border border-gray-200 focus:outline-none focus:border-cyan-400 field-sizing-content text-base bg-white",
+              placeholder: placeholder,
+              required: true
+            = render "shared/error_messages", model: form.object, attribute: :body
+            .flex.justify-end.mt-2
+              = form.submit "送信する",
+              class: "cursor-pointer border border-cyan-600 text-cyan-600 font-semibold px-5 py-2 rounded-lg hover:bg-cyan-50 text-base transition-colors"
 
 = link_to "やり取り一覧へ", conversations_path, class: "mt-4 flex items-center justify-center text-sm text-gray-500 hover:text-gray-700 underline"

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe Item, type: :model do
     let(:buyer) { create(:user) }
     let(:item) { create(:item, :sold, user: seller) }
 
-    before { create(:entry, :won, user: buyer, item: item)}
+    before { create(:entry, :won, user: buyer, item: item) }
 
     context "when user is seller" do
       it "returns true" do

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -165,6 +165,33 @@ RSpec.describe Item, type: :model do
     end
   end
 
+  describe "#participant?" do
+    let(:seller) { create(:user) }
+    let(:admin) { create(:user, uid: 123) }
+    let(:buyer) { create(:user) }
+    let(:item) { create(:item, :sold, user: seller) }
+
+    before { create(:entry, :won, user: buyer, item: item)}
+
+    context "when user is seller" do
+      it "returns true" do
+        expect(item.participant?(seller)).to be true
+      end
+    end
+
+    context "when user is buyer" do
+      it "returns true" do
+        expect(item.participant?(buyer)).to be true
+      end
+    end
+
+    context "when user is admin and is not participant" do
+      it "returns false" do
+        expect(item.participant?(admin)).to be false
+      end
+    end
+  end
+
   describe "#deadline_must_be_today_or_later" do
     let(:item) { build(:item, :with_item_image, entry_deadline_at: entry_deadline_at) }
 

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -82,42 +82,6 @@ RSpec.describe Item, type: :model do
     end
   end
 
-  describe "#other_user_for" do
-    let(:seller) { create(:user) }
-    let(:item) { create(:item, :sold, user: seller) }
-    let(:buyer) { create(:user) }
-
-    before { create(:entry, :won, item: item, user: buyer) }
-
-    context "when current user is seller" do
-      it "returns buyer" do
-        expect(item.other_user_for(seller)).to eq(buyer)
-      end
-    end
-
-    context "when current user is buyer" do
-      it "returns seller" do
-        expect(item.other_user_for(buyer)).to eq(seller)
-      end
-    end
-
-    context "when current user is admin and not involved" do
-      it "returns nil" do
-        admin = create(:user, :admin)
-
-        expect(item.other_user_for(admin)).to be_nil
-      end
-    end
-
-    context "when current user is admin and is seller" do
-      it "returns buyer" do
-        admin = seller
-
-        expect(item.other_user_for(admin)).to eq(buyer)
-      end
-    end
-  end
-
   describe "#close!" do
     let(:user) { create(:user) }
     let(:item) { create(:item, :published, user: user) }

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -13,33 +13,6 @@ RSpec.describe Message, type: :model do
   end
 
   describe "#recipient" do
-    context "when sender is admin and is seller" do
-      it "returns buyer" do
-        seller.update!(admin: true)
-        message = create(:message, item: item, user: seller)
-
-        expect(message.recipient).to eq buyer
-      end
-    end
-
-    context "when sender is admin and is buyer" do
-      it "returns seller" do
-        buyer.update!(admin: true)
-        message = create(:message, item: item, user: buyer)
-
-        expect(message.recipient).to eq seller
-      end
-    end
-
-    context "when sender is admin and is not seller or buyer" do
-      it "returns nil" do
-        admin = create(:user, admin: true)
-        message = create(:message, item: item, user: admin)
-
-        expect(message.recipient).to be_nil
-      end
-    end
-
     context "when sender is seller" do
       it "returns buyer" do
         message = create(:message, item: item, user: seller)

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -1,18 +1,61 @@
 require 'rails_helper'
 
 RSpec.describe Message, type: :model do
+  let(:seller) { create(:user) }
+  let(:buyer) { create(:user) }
+  let!(:item) { create(:item, :sold, user: seller) }
+
   before do
     ActiveJob::Base.queue_adapter = :test
     webhook = stub_discord_webhook
+
+    create(:entry, :won, item: item, user: buyer)
+  end
+
+  describe "#recipient" do
+    context "when sender is admin and is seller" do
+      it "returns buyer" do
+        seller.update!(admin: true)
+        message = create(:message, item: item, user: seller)
+
+        expect(message.recipient).to eq buyer
+      end
+    end
+
+    context "when sender is admin and is buyer" do
+      it "returns seller" do
+        buyer.update!(admin: true)
+        message = create(:message, item: item, user: buyer)
+
+        expect(message.recipient).to eq seller
+      end
+    end
+
+    context "when sender is admin and is not seller or buyer" do
+      it "returns nil" do
+        admin = create(:user, admin: true)
+        message = create(:message, item: item, user: admin)
+
+        expect(message.recipient).to be_nil
+      end
+    end
+
+    context "when sender is seller" do
+      it "returns buyer" do
+        message = create(:message, item: item, user: seller)
+        expect(message.recipient).to eq buyer
+      end
+    end
+
+    context "when sender is buyer" do
+      it "returns seller" do
+        message = create(:message, item: item, user: buyer)
+        expect(message.recipient).to eq seller
+      end
+    end
   end
 
   describe "#create_notifications" do
-    let(:seller) { create(:user) }
-    let(:buyer) { create(:user) }
-    let!(:item) { create(:item, :sold, user: seller) }
-
-    before { create(:entry, :won, item: item, user: buyer) }
-
     it "creates notification job" do
       message = create(:message, item: item, user: buyer)
       expect(NotifyMessageCreatedJob).to have_been_enqueued.with(message.id)

--- a/spec/requests/messages_spec.rb
+++ b/spec/requests/messages_spec.rb
@@ -33,10 +33,23 @@ RSpec.describe "/messages", type: :request do
   end
 
   describe "POST /create" do
-    before { login(user) }
+    context "when admin tries to message for unrelated item" do
+      let(:admin) { create(:user, :admin, uid: "123") }
+
+      before { login (admin) }
+
+      it "redirects to messages index" do
+        expect {
+          post conversation_messages_path(item), params: { message: attributes_for(:message, item: item, user: admin) }
+        }.not_to change(Message, :count)
+        expect(response).to redirect_to(conversation_messages_path(item))
+      end
+    end
 
     context "with valid parameters" do
       let(:valid_attributes) { attributes_for(:message, item: item, user: user) }
+
+      before { login(user) }
 
       it "creates a new Message" do
         expect {
@@ -48,6 +61,8 @@ RSpec.describe "/messages", type: :request do
 
     context "with invalid parameters" do
       let(:invalid_attributes) { attributes_for(:message, item: item, user: user, body: "") }
+
+      before { login(user) }
 
       it "does not create a new Message" do
         expect {


### PR DESCRIPTION
## Issue
- #336 
## 概要
メッセージ受信者を指定するメソッドとして使用していたItemのother_user_forメソッドをMessageモデルに移行した。合わせてItemモデルのテストを削除し、Messageモデルにテストを追加した。