### PR TITLE
追記処理をモデルに持たせるよう修正

### DIFF
--- a/app/controllers/items/drafts_controller.rb
+++ b/app/controllers/items/drafts_controller.rb
@@ -28,6 +28,6 @@ class Items::DraftsController < ApplicationController
   end
 
   def item_params
-    params.expect(item: [ *Item::EDITABLE_FIELDS ])
+    params.expect(item: [ *Item::FIELDS_FOR_DRAFT ])
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -80,7 +80,7 @@ class ItemsController < ApplicationController
     if @item.draft?
       params.expect(item: [ *Item::FIELDS_FOR_DRAFT ])
     else
-      params.expect(item: [ :title_append, :description_append, :payment_method_append, *Item::FIELDS_FOR_PUBLISHED ])
+      params.expect(item: [ *Item::FIELDS_FOR_PUBLISHED ])
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -44,14 +44,7 @@ class ItemsController < ApplicationController
 
   # PATCH/PUT /items/1
   def update
-    @item.assign_attributes(item_params)
-    title_append = params[:item][:title_append]
-    description_append = params[:item][:description_append]
-    payment_method_append = params[:item][:payment_method_append]
-
-    @item.title = [ @item.title, title_append ].join(" ") if title_append.present?
-    @item.description = [ @item.description.presence, description_append ].compact.join("\n") if description_append.present?
-    @item.payment_method = [ @item.payment_method, payment_method_append ].join(" ") if payment_method_append.present?
+    @item.assign_attributes(item_update_params)
 
     if @item.valid?(:publish)
       @item.status = :published
@@ -80,7 +73,15 @@ class ItemsController < ApplicationController
 
   # Only allow a list of trusted parameters through.
   def item_params
-    params.expect(item: [ :title_append, :description_append, :payment_method_append, *Item::EDITABLE_FIELDS ])
+    params.expect(item: [ *Item::EDITABLE_FIELDS ])
+  end
+
+  def item_update_params
+    if @item.draft?
+      params.expect(item: [ *Item::EDITABLE_FIELDS ])
+    else
+      params.expect(item: [ :title_append, :description_append, :payment_method_append, *Item::UPDATABLE_FIELDS ])
+    end
   end
 
   def ensure_item_editable

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -31,7 +31,7 @@ class ItemsController < ApplicationController
 
   # POST /items
   def create
-    @item = current_user.items.build(item_params)
+    @item = current_user.items.build(item_create_params)
 
     if @item.valid?(:publish)
       @item.status = :published
@@ -72,15 +72,15 @@ class ItemsController < ApplicationController
   end
 
   # Only allow a list of trusted parameters through.
-  def item_params
-    params.expect(item: [ *Item::EDITABLE_FIELDS ])
+  def item_create_params
+    params.expect(item: [ *Item::FIELDS_FOR_DRAFT ])
   end
 
   def item_update_params
     if @item.draft?
-      params.expect(item: [ *Item::EDITABLE_FIELDS ])
+      params.expect(item: [ *Item::FIELDS_FOR_DRAFT ])
     else
-      params.expect(item: [ :title_append, :description_append, :payment_method_append, *Item::UPDATABLE_FIELDS ])
+      params.expect(item: [ :title_append, :description_append, :payment_method_append, *Item::FIELDS_FOR_PUBLISHED ])
     end
   end
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -47,8 +47,8 @@ class Item < ApplicationRecord
   scope :expired, -> { where.not(id: not_expired).where(status: :published) }
   scope :commentable, -> { where.not(status: :draft) }
 
-  EDITABLE_FIELDS = [ :title, :description, :price, :shipping_fee_payer, :payment_method, :entry_deadline_at, images: [] ].freeze
-  UPDATABLE_FIELDS = (EDITABLE_FIELDS - [ :title, :description, :payment_method ]).freeze
+  FIELDS_FOR_DRAFT = [ :title, :description, :price, :shipping_fee_payer, :payment_method, :entry_deadline_at, images: [] ].freeze
+  FIELDS_FOR_PUBLISHED = (FIELDS_FOR_DRAFT - [ :title, :description, :payment_method ]).freeze
 
   def close!(reason: :user_action)
     update!(status: :closed)

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -27,16 +27,20 @@ class Item < ApplicationRecord
   validates :images, limit: { max: MAX_COUNT }, content_type: ALLOWED_TYPES, size: { less_than: MAX_SIZE_MB.megabytes }
 
   validates :title, length: { maximum: 255 }, presence: true, on: :publish
+  validates :description, length: { maximum: 1000 }, on: :publish
   validates :price, presence: true, on: :publish
   validates :shipping_fee_payer, presence: { message: "を選択してください" }, on: :publish
-  validates :payment_method, presence: { message: "を選択してください" }, on: :publish
+  validates :payment_method, length: { maximum: 255 }, presence: { message: "を選択してください" }, on: :publish
   validates :entry_deadline_at, presence: true, on: :publish
   validates :images, attached: { message: "を1枚以上選択してください" }, on: :publish
+  validate :combined_title_must_be_within_limit, on: :publish
+  validate :combined_description_must_be_within_limit, on: :publish
+  validate :combined_payment_method_must_be_within_limit, on: :publish
   validate :deadline_must_be_today_or_later, on: :publish
   validate :price_cannot_be_changed_after_published, on: :publish
   validate :deadline_cannot_be_changed_earlier_after_published, on: :publish
 
-  before_validation :append_additional_contents
+  before_save :append_additional_contents
   before_save :set_entry_deadline_at_end_of_day, if: :will_save_change_to_entry_deadline_at?
 
   after_save_commit :comment_watch_by_seller, if: -> { saved_change_to_attribute?(:status, to: "published") }
@@ -70,6 +74,24 @@ class Item < ApplicationRecord
   end
 
   private
+
+  def combined_title_must_be_within_limit
+    if title_append.present? && [ title, title_append ].join(" ").length > 255
+      errors.add(:title, "は合わせて255文字以内で入力してください")
+    end
+  end
+
+  def combined_description_must_be_within_limit
+    if description_append.present? && [ description, description_append ].compact.join("\n").length > 255
+      errors.add(:title, "は合わせて1000文字以内で入力してください")
+    end
+  end
+
+  def combined_payment_method_must_be_within_limit
+    if payment_method_append.present? && [ payment_method, payment_method_append ].join(" ").length > 255
+      errors.add(:payment_method, "は合わせて255文字以内で入力してください")
+    end
+  end
 
   def deadline_must_be_today_or_later
     return if entry_deadline_at.nil? || entry_deadline_at.to_date >= Date.current

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -36,6 +36,7 @@ class Item < ApplicationRecord
   validate :price_cannot_be_changed_after_published, on: :publish
   validate :deadline_cannot_be_changed_earlier_after_published, on: :publish
 
+  before_validation :append_additional_contents
   before_save :set_entry_deadline_at_end_of_day, if: :will_save_change_to_entry_deadline_at?
 
   after_save_commit :comment_watch_by_seller, if: -> { saved_change_to_attribute?(:status, to: "published") }
@@ -47,6 +48,7 @@ class Item < ApplicationRecord
   scope :commentable, -> { where.not(status: :draft) }
 
   EDITABLE_FIELDS = [ :title, :description, :price, :shipping_fee_payer, :payment_method, :entry_deadline_at, images: [] ].freeze
+  UPDATABLE_FIELDS = (EDITABLE_FIELDS - [ :title, :description, :payment_method ]).freeze
 
   def close!(reason: :user_action)
     update!(status: :closed)
@@ -89,6 +91,20 @@ class Item < ApplicationRecord
       if new_deadline < old_deadline
         errors.add(:entry_deadline_at, "は元の締切日以降に設定してください")
       end
+    end
+  end
+
+  def append_additional_contents
+    if title_append.present? && !title&.include?(title_append)
+      self.title = [ title, title_append ].join(" ")
+    end
+
+    if description_append.present? && !description&.include?(description_append)
+      self.description = [ description, description_append ].compact.join("\n")
+    end
+
+    if payment_method_append.present? && !payment_method&.include?(payment_method_append)
+      self.payment_method = [ payment_method, payment_method_append ].join(" ")
     end
   end
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -18,8 +18,6 @@ class Item < ApplicationRecord
   enum :shipping_fee_payer, { buyer: 0, seller: 1 }
   enum :status, { draft: 0, published: 1, sold: 2, closed: 3 }
 
-  attr_accessor :title_append, :description_append, :payment_method_append
-
   MAX_COUNT = 5
   ALLOWED_TYPES = %w[ image/png image/jpeg ].freeze
   MAX_SIZE_MB = 5
@@ -36,14 +34,10 @@ class Item < ApplicationRecord
   validates :payment_method, length: { maximum: MAX_STRING_LENGTH }, presence: true, on: :publish
   validates :entry_deadline_at, presence: true, on: :publish
   validates :images, attached: { message: "を1枚以上選択してください" }, on: :publish
-  validate :combined_title_must_be_within_limit, on: :publish
-  validate :combined_description_must_be_within_limit, on: :publish
-  validate :combined_payment_method_must_be_within_limit, on: :publish
   validate :deadline_must_be_today_or_later, on: :publish
   validate :price_cannot_be_changed_after_published, on: :publish
   validate :deadline_cannot_be_changed_earlier_after_published, on: :publish
 
-  before_save :append_additional_contents
   before_save :set_entry_deadline_at_end_of_day, if: :will_save_change_to_entry_deadline_at?
 
   after_save_commit :comment_watch_by_seller, if: -> { saved_change_to_attribute?(:status, to: "published") }
@@ -55,7 +49,7 @@ class Item < ApplicationRecord
   scope :commentable, -> { where.not(status: :draft) }
 
   FIELDS_FOR_DRAFT = [ :title, :description, :price, :shipping_fee_payer, :payment_method, :entry_deadline_at, images: [] ].freeze
-  FIELDS_FOR_PUBLISHED = (FIELDS_FOR_DRAFT - [ :title, :description, :payment_method ]).freeze
+  FIELDS_FOR_PUBLISHED = (FIELDS_FOR_DRAFT - [ :price, :shipping_fee_payer ]).freeze
 
   def close!(reason: :user_action)
     update!(status: :closed)
@@ -78,38 +72,6 @@ class Item < ApplicationRecord
 
   private
 
-  def combined_string_with_space(original, append)
-    return original if append.blank?
-    return original if original&.include?(append)
-
-    [ original, append ].join(" ")
-  end
-
-  def combined_text_with_indent(original, append)
-    return original if append.blank?
-    return original if original&.include?(append)
-
-    [ original, append ].compact_blank.join("\n")
-  end
-
-  def combined_title_must_be_within_limit
-    if combined_string_with_space(title, title_append).length > MAX_STRING_LENGTH
-      errors.add(:title, "は合わせて#{MAX_STRING_LENGTH}文字以内で入力してください")
-    end
-  end
-
-  def combined_description_must_be_within_limit
-    if combined_text_with_indent(description, description_append).length > MAX_TEXT_LENGTH
-      errors.add(:description, "は合わせて#{MAX_TEXT_LENGTH}文字以内で入力してください")
-    end
-  end
-
-  def combined_payment_method_must_be_within_limit
-    if combined_string_with_space(payment_method, payment_method_append).length > MAX_STRING_LENGTH
-      errors.add(:payment_method, "は合わせて#{MAX_STRING_LENGTH}文字以内で入力してください")
-    end
-  end
-
   def deadline_must_be_today_or_later
     return if entry_deadline_at.nil? || entry_deadline_at.to_date >= Date.current
 
@@ -131,12 +93,6 @@ class Item < ApplicationRecord
         errors.add(:entry_deadline_at, "は元の締切日以降に設定してください")
       end
     end
-  end
-
-  def append_additional_contents
-    self.title = combined_string_with_space(title, title_append)
-    self.description = combined_text_with_indent(description, description_append)
-    self.payment_method = combined_string_with_space(payment_method, payment_method_append)
   end
 
   def set_entry_deadline_at_end_of_day

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -83,7 +83,7 @@ class Item < ApplicationRecord
 
   def combined_description_must_be_within_limit
     if description_append.present? && [ description, description_append ].compact.join("\n").length > 255
-      errors.add(:title, "は合わせて1000文字以内で入力してください")
+      errors.add(:description, "は合わせて1000文字以内で入力してください")
     end
   end
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -26,11 +26,14 @@ class Item < ApplicationRecord
 
   validates :images, limit: { max: MAX_COUNT }, content_type: ALLOWED_TYPES, size: { less_than: MAX_SIZE_MB.megabytes }
 
-  validates :title, length: { maximum: 255 }, presence: true, on: :publish
-  validates :description, length: { maximum: 1000 }, on: :publish
+  MAX_STRING_LENGTH = 255
+  MAX_TEXT_LENGTH = 1000
+
+  validates :title, length: { maximum: MAX_STRING_LENGTH }, presence: true, on: :publish
+  validates :description, length: { maximum: MAX_TEXT_LENGTH }, on: :publish
   validates :price, presence: true, on: :publish
   validates :shipping_fee_payer, presence: { message: "を選択してください" }, on: :publish
-  validates :payment_method, length: { maximum: 255 }, presence: { message: "を選択してください" }, on: :publish
+  validates :payment_method, length: { maximum: MAX_STRING_LENGTH }, presence: true, on: :publish
   validates :entry_deadline_at, presence: true, on: :publish
   validates :images, attached: { message: "を1枚以上選択してください" }, on: :publish
   validate :combined_title_must_be_within_limit, on: :publish
@@ -75,21 +78,35 @@ class Item < ApplicationRecord
 
   private
 
+  def combined_string_with_space(original, append)
+    return original if append.blank?
+    return original if original&.include?(append)
+
+    [ original, append ].join(" ")
+  end
+
+  def combined_text_with_indent(original, append)
+    return original if append.blank?
+    return original if original&.include?(append)
+
+    [ original, append ].compact_blank.join("\n")
+  end
+
   def combined_title_must_be_within_limit
-    if title_append.present? && [ title, title_append ].join(" ").length > 255
-      errors.add(:title, "は合わせて255文字以内で入力してください")
+    if combined_string_with_space(title, title_append).length > MAX_STRING_LENGTH
+      errors.add(:title, "は合わせて#{MAX_STRING_LENGTH}文字以内で入力してください")
     end
   end
 
   def combined_description_must_be_within_limit
-    if description_append.present? && [ description, description_append ].compact.join("\n").length > 255
-      errors.add(:description, "は合わせて1000文字以内で入力してください")
+    if combined_text_with_indent(description, description_append).length > MAX_TEXT_LENGTH
+      errors.add(:description, "は合わせて#{MAX_TEXT_LENGTH}文字以内で入力してください")
     end
   end
 
   def combined_payment_method_must_be_within_limit
-    if payment_method_append.present? && [ payment_method, payment_method_append ].join(" ").length > 255
-      errors.add(:payment_method, "は合わせて255文字以内で入力してください")
+    if combined_string_with_space(payment_method, payment_method_append).length > MAX_STRING_LENGTH
+      errors.add(:payment_method, "は合わせて#{MAX_STRING_LENGTH}文字以内で入力してください")
     end
   end
 
@@ -117,17 +134,9 @@ class Item < ApplicationRecord
   end
 
   def append_additional_contents
-    if title_append.present? && !title&.include?(title_append)
-      self.title = [ title, title_append ].join(" ")
-    end
-
-    if description_append.present? && !description&.include?(description_append)
-      self.description = [ description, description_append ].compact.join("\n")
-    end
-
-    if payment_method_append.present? && !payment_method&.include?(payment_method_append)
-      self.payment_method = [ payment_method, payment_method_append ].join(" ")
-    end
+    self.title = combined_string_with_space(title, title_append)
+    self.description = combined_text_with_indent(description, description_append)
+    self.payment_method = combined_string_with_space(payment_method, payment_method_append)
   end
 
   def set_entry_deadline_at_end_of_day

--- a/app/views/items/_form.html.slim
+++ b/app/views/items/_form.html.slim
@@ -6,13 +6,13 @@
 
   div
     = form.label :title, class: "text-sm font-semibold text-gray-700 block mb-1"
-    = form.text_field :title, maxlength: 255,
+    = form.text_field :title, maxlength: Item::MAX_STRING_LENGTH,
       class: "w-full px-3 py-2 bg-white border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:border-transparent \
       read-only:bg-gray-100 read-only:focus:ring-0 read-only:focus:border-gray-300", readonly: item.published?
     = render "shared/error_messages", model: item, attribute: :title
     - if item.published?
       = form.label :title_append, class: "text-sm  text-gray-600 block mt-2 mb-1"
-      = form.text_field :title_append, maxlength: 255,
+      = form.text_field :title_append, maxlength: Item::MAX_STRING_LENGTH,
       class: "w-full px-3 py-2 bg-white border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:border-transparent"
 
   div[data-controller="image-preview"
@@ -65,13 +65,13 @@
       class: "w-full px-3 py-2 bg-white border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:border-transparent \
       min-h-32 field-sizing-content placeholder-gray-400 read-only:bg-gray-100 read-only:focus:ring-0 read-only:min-h-[46px] read-only:field-sizing-content",
       readonly: item.published?,
-      maxlength: 1000
+      maxlength: Item::MAX_TEXT_LENGTH
     = render "shared/error_messages", model: item, attribute: :description
     - if item.published?
       = form.label :description_append, class: "text-sm text-gray-600 block mt-2 mb-1"
       = form.textarea :description_append, class: "w-full px-3 py-2 bg-white border border-gray-300 rounded-lg text-sm \
       focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:border-transparent min-h-32 field-sizing-content",
-      maxlength: 1000
+      maxlength: Item::MAX_TEXT_LENGTH
 
   div
     .flex.items-center.gap-x-2.mb-1
@@ -100,13 +100,13 @@
 
   div
     = form.label :payment_method, class: "font-semibold text-sm block text-gray-700 mb-1"
-    = form.text_field :payment_method, maxlength: 255,
+    = form.text_field :payment_method, maxlength: Item::MAX_STRING_LENGTH,
       placeholder: "入力例）PayPayまたは口座振り込み",
       class: "w-full px-3 py-2 bg-white border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-cyan-500 \
       focus:border-transparent placeholder-gray-400 read-only:bg-gray-100 read-only:focus:ring-0", readonly: item.published?
     - if item.published?
       = form.label :payment_method_append, class: "text-sm text-gray-600 block mt-2 mb-1"
-      = form.text_field :payment_method_append, maxlength: 255,
+      = form.text_field :payment_method_append, maxlength: Item::MAX_STRING_LENGTH,
         class: "w-full px-3 py-2 bg-white border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-cyan-500 \
         focus:border-transparent"
     = render "shared/error_messages", model: item, attribute: :payment_method

--- a/app/views/items/_form.html.slim
+++ b/app/views/items/_form.html.slim
@@ -7,13 +7,8 @@
   div
     = form.label :title, class: "text-sm font-semibold text-gray-700 block mb-1"
     = form.text_field :title, maxlength: Item::MAX_STRING_LENGTH,
-      class: "w-full px-3 py-2 bg-white border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:border-transparent \
-      read-only:bg-gray-100 read-only:focus:ring-0 read-only:focus:border-gray-300", readonly: item.published?
-    = render "shared/error_messages", model: item, attribute: :title
-    - if item.published?
-      = form.label :title_append, class: "text-sm  text-gray-600 block mt-2 mb-1"
-      = form.text_field :title_append, maxlength: Item::MAX_STRING_LENGTH,
       class: "w-full px-3 py-2 bg-white border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:border-transparent"
+    = render "shared/error_messages", model: item, attribute: :title
 
   div[data-controller="image-preview"
   data={ "image-preview-max-count-value": Item::MAX_COUNT,
@@ -61,17 +56,11 @@
       = form.label :description, style: "display: block", class: "font-semibold text-sm block text-gray-700"
       span.text-xs.text-gray-500 任意
     = form.textarea :description,
-      placeholder: (item.published? ? nil : "商品の特徴や状態などを1000字以内でご入力ください\n\n入力例）カバーに傷みがありますが、中は書き込みや破れなどはなく綺麗な状態です"),
+      placeholder: "商品の特徴や状態などをご入力ください\n\n入力例）カバーに傷みがありますが、中は書き込みや破れなどはなく綺麗な状態です",
       class: "w-full px-3 py-2 bg-white border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:border-transparent \
-      min-h-32 field-sizing-content placeholder-gray-400 read-only:bg-gray-100 read-only:focus:ring-0 read-only:min-h-[46px] read-only:field-sizing-content",
-      readonly: item.published?,
+      min-h-32 field-sizing-content placeholder-gray-400",
       maxlength: Item::MAX_TEXT_LENGTH
     = render "shared/error_messages", model: item, attribute: :description
-    - if item.published?
-      = form.label :description_append, class: "text-sm text-gray-600 block mt-2 mb-1"
-      = form.textarea :description_append, class: "w-full px-3 py-2 bg-white border border-gray-300 rounded-lg text-sm \
-      focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:border-transparent min-h-32 field-sizing-content",
-      maxlength: Item::MAX_TEXT_LENGTH
 
   div
     .flex.items-center.gap-x-2.mb-1
@@ -103,12 +92,7 @@
     = form.text_field :payment_method, maxlength: Item::MAX_STRING_LENGTH,
       placeholder: "入力例）PayPayまたは口座振り込み",
       class: "w-full px-3 py-2 bg-white border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-cyan-500 \
-      focus:border-transparent placeholder-gray-400 read-only:bg-gray-100 read-only:focus:ring-0", readonly: item.published?
-    - if item.published?
-      = form.label :payment_method_append, class: "text-sm text-gray-600 block mt-2 mb-1"
-      = form.text_field :payment_method_append, maxlength: Item::MAX_STRING_LENGTH,
-        class: "w-full px-3 py-2 bg-white border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-cyan-500 \
-        focus:border-transparent"
+      focus:border-transparent placeholder-gray-400"
     = render "shared/error_messages", model: item, attribute: :payment_method
 
   div
@@ -125,7 +109,7 @@
   .pt-2
     - if item.draft?
       p.text-red-400.text-sm.text-sm.mb-3
-        | 出品後はご入力いただいた内容の削除はできず、商品情報（商品名・商品説明・お支払い方法）の追加と締切の延長のみ行うことができます。出品前に内容をお確かめください。
+        | 出品後は商品名・商品説明・お支払い方法の編集と締切の延長のみ行うことができます。画像の削除や価格・配送料の負担の変更はできませんので出品前に内容をお確かめください。
     = form.submit I18n.t("helpers.submit.item.publish.#{item.status}"), name: "publish",
     class: "cursor-pointer w-full block px-4 py-2.5 rounded-lg bg-cyan-600 text-white text-sm font-semibold hover:bg-cyan-700 transition-colors text-center"
 

--- a/app/views/items/_form.html.slim
+++ b/app/views/items/_form.html.slim
@@ -11,7 +11,7 @@
       read-only:bg-gray-100 read-only:focus:ring-0 read-only:focus:border-gray-300", readonly: item.published?
     = render "shared/error_messages", model: item, attribute: :title
     - if item.published?
-      = form.label "商品名の追記", class: "text-sm  text-gray-600 block mt-2 mb-1"
+      = form.label :title_append, class: "text-sm  text-gray-600 block mt-2 mb-1"
       = form.text_field :title_append,
       class: "w-full px-3 py-2 bg-white border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:border-transparent"
 
@@ -67,7 +67,7 @@
       readonly: item.published?
     = render "shared/error_messages", model: item, attribute: :description
     - if item.published?
-      = form.label "商品説明の追記", class: "text-sm text-gray-600 block mt-2 mb-1"
+      = form.label :description_append, class: "text-sm text-gray-600 block mt-2 mb-1"
       = form.textarea :description_append, class: "w-full px-3 py-2 bg-white border border-gray-300 rounded-lg text-sm \
       focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:border-transparent min-h-32 field-sizing-content"
 
@@ -103,7 +103,7 @@
       class: "w-full px-3 py-2 bg-white border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-cyan-500 \
       focus:border-transparent placeholder-gray-400 read-only:bg-gray-100 read-only:focus:ring-0", readonly: item.published?
     - if item.published?
-      = form.label "お支払い方法の追記", class: "text-sm text-gray-600 block mt-2 mb-1"
+      = form.label :payment_method_append, class: "text-sm text-gray-600 block mt-2 mb-1"
       = form.text_field :payment_method_append,
         class: "w-full px-3 py-2 bg-white border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-cyan-500 \
         focus:border-transparent"

--- a/app/views/items/_form.html.slim
+++ b/app/views/items/_form.html.slim
@@ -12,7 +12,7 @@
     = render "shared/error_messages", model: item, attribute: :title
     - if item.published?
       = form.label :title_append, class: "text-sm  text-gray-600 block mt-2 mb-1"
-      = form.text_field :title_append,
+      = form.text_field :title_append, maxlength: 255,
       class: "w-full px-3 py-2 bg-white border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:border-transparent"
 
   div[data-controller="image-preview"
@@ -61,15 +61,17 @@
       = form.label :description, style: "display: block", class: "font-semibold text-sm block text-gray-700"
       span.text-xs.text-gray-500 任意
     = form.textarea :description,
-      placeholder: (item.published? ? nil : "商品の特徴や状態などをご入力ください\n\n入力例）カバーに傷みがありますが、中は書き込みや破れなどはなく綺麗な状態です"),
+      placeholder: (item.published? ? nil : "商品の特徴や状態などを1000字以内でご入力ください\n\n入力例）カバーに傷みがありますが、中は書き込みや破れなどはなく綺麗な状態です"),
       class: "w-full px-3 py-2 bg-white border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:border-transparent \
       min-h-32 field-sizing-content placeholder-gray-400 read-only:bg-gray-100 read-only:focus:ring-0 read-only:min-h-[46px] read-only:field-sizing-content",
-      readonly: item.published?
+      readonly: item.published?,
+      maxlength: 1000
     = render "shared/error_messages", model: item, attribute: :description
     - if item.published?
       = form.label :description_append, class: "text-sm text-gray-600 block mt-2 mb-1"
       = form.textarea :description_append, class: "w-full px-3 py-2 bg-white border border-gray-300 rounded-lg text-sm \
-      focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:border-transparent min-h-32 field-sizing-content"
+      focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:border-transparent min-h-32 field-sizing-content",
+      maxlength: 1000
 
   div
     .flex.items-center.gap-x-2.mb-1
@@ -98,13 +100,13 @@
 
   div
     = form.label :payment_method, class: "font-semibold text-sm block text-gray-700 mb-1"
-    = form.text_field :payment_method,
+    = form.text_field :payment_method, maxlength: 255,
       placeholder: "入力例）PayPayまたは口座振り込み",
       class: "w-full px-3 py-2 bg-white border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-cyan-500 \
       focus:border-transparent placeholder-gray-400 read-only:bg-gray-100 read-only:focus:ring-0", readonly: item.published?
     - if item.published?
       = form.label :payment_method_append, class: "text-sm text-gray-600 block mt-2 mb-1"
-      = form.text_field :payment_method_append,
+      = form.text_field :payment_method_append, maxlength: 255,
         class: "w-full px-3 py-2 bg-white border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-cyan-500 \
         focus:border-transparent"
     = render "shared/error_messages", model: item, attribute: :payment_method

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -15,12 +15,15 @@ ja:
     attributes:
       item:
         title: 商品名
+        title_append: 商品名の追記
         images: 商品画像
         image: 商品画像
         description: 商品説明
+        description_append: 商品説明の追記
         price: 価格
         shipping_fee_payer: 送料負担
         payment_method: お支払い方法
+        payment_method_append: お支払い方法の追記
         entry_deadline_at: 購入希望申請締切
       comment:
         body: コメント

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -15,15 +15,12 @@ ja:
     attributes:
       item:
         title: 商品名
-        title_append: 商品名の追記
         images: 商品画像
         image: 商品画像
         description: 商品説明
-        description_append: 商品説明の追記
         price: 価格
         shipping_fee_payer: 送料負担
         payment_method: お支払い方法
-        payment_method_append: お支払い方法の追記
         entry_deadline_at: 購入希望申請締切
       comment:
         body: コメント

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -192,36 +192,6 @@ RSpec.describe Item, type: :model do
     end
   end
 
-  describe "#combined_title_must_be_within_limit" do
-    let(:item) { build(:item, :published, title: "Alice's Adventures in Wonderland") }
-
-    it "validates title to be within limit" do
-      item.title_append = "a" * 250
-      expect(item.valid?(:publish)).to be false
-      expect(item.errors[:title]).to include("は合わせて255文字以内で入力してください")
-    end
-  end
-
-  describe "#combined_description_must_be_within_limit" do
-    let(:item) { build(:item, :published, description: "Alice wonders in Wonderland") }
-
-    it "validates title to be within limit" do
-      item.description_append = "a" * 999
-      expect(item.valid?(:publish)).to be false
-      expect(item.errors[:description]).to include("は合わせて1000文字以内で入力してください")
-    end
-  end
-
-  describe "#combined_payment_method_must_be_within_limit" do
-    let(:item) { build(:item, :published, payment_method: "PayPay") }
-
-    it "validates title to be within limit" do
-      item.payment_method_append = "a" * 250
-      expect(item.valid?(:publish)).to be false
-      expect(item.errors[:payment_method]).to include("は合わせて255文字以内で入力してください")
-    end
-  end
-
   describe "#deadline_must_be_today_or_later" do
     let(:item) { build(:item, :with_item_image, entry_deadline_at: entry_deadline_at) }
 
@@ -303,38 +273,6 @@ RSpec.describe Item, type: :model do
         item.assign_attributes(entry_deadline_at: Date.current + 2.days)
 
         expect(item.valid?(:publish)).to be true
-      end
-    end
-  end
-
-  describe "#append_additional_contents" do
-    context "when append contents exists" do
-      let(:item) { build(:item, :published, title: "Alice's Adventures in Wonderland", description: "Alice wonders in Wonderland", payment_method: "PayPay") }
-
-      it "adds to original title" do
-        item.title_append = "by Lewis Carroll"
-        item.description_append = "It's a classic children's book."
-        item.payment_method_append = "PayPal"
-        item.save!
-
-        expect(item.title).to eq("Alice's Adventures in Wonderland by Lewis Carroll")
-        expect(item.description).to eq("Alice wonders in Wonderland\nIt's a classic children's book.")
-        expect(item.payment_method).to eq("PayPay PayPal")
-      end
-    end
-
-    context "when append contents are already joined" do
-      let(:item) { build(:item, :published, title: "Alice's Adventures in Wonderland by Lewis Carroll", description: "Alice wonders in Wonderland\nIt's a classic children's book.", payment_method: "PayPay PayPal") }
-
-      it "does not joins twice" do
-        item.title_append = "by Lewis Carroll"
-        item.description_append = "It's a classic children's book."
-        item.payment_method_append = "PayPal"
-        item.save!
-
-        expect(item.title).to eq("Alice's Adventures in Wonderland by Lewis Carroll")
-        expect(item.description).to eq("Alice wonders in Wonderland\nIt's a classic children's book.")
-        expect(item.payment_method).to eq("PayPay PayPal")
       end
     end
   end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -197,7 +197,6 @@ RSpec.describe Item, type: :model do
 
     it "validates title to be within limit" do
       item.title_append = "a" * 250
-      item.send(:append_additional_contents)
       expect(item.valid?(:publish)).to be false
       expect(item.errors[:title]).to include("は合わせて255文字以内で入力してください")
     end
@@ -208,7 +207,6 @@ RSpec.describe Item, type: :model do
 
     it "validates title to be within limit" do
       item.description_append = "a" * 999
-      item.send(:append_additional_contents)
       expect(item.valid?(:publish)).to be false
       expect(item.errors[:description]).to include("は合わせて1000文字以内で入力してください")
     end
@@ -219,7 +217,6 @@ RSpec.describe Item, type: :model do
 
     it "validates title to be within limit" do
       item.payment_method_append = "a" * 250
-      item.send(:append_additional_contents)
       expect(item.valid?(:publish)).to be false
       expect(item.errors[:payment_method]).to include("は合わせて255文字以内で入力してください")
     end
@@ -311,23 +308,33 @@ RSpec.describe Item, type: :model do
   end
 
   describe "#append_additional_contents" do
-    context "when title_append exists" do
-      let(:item) { create(:item, :published, title: "Alice's Adventures in Wonderland") }
+    context "when append contents exists" do
+      let(:item) { build(:item, :published, title: "Alice's Adventures in Wonderland", description: "Alice wonders in Wonderland", payment_method: "PayPay") }
 
       it "adds to original title" do
         item.title_append = "by Lewis Carroll"
-        item.send(:append_additional_contents)
+        item.description_append = "It's a classic children's book."
+        item.payment_method_append = "PayPal"
+        item.save!
+
         expect(item.title).to eq("Alice's Adventures in Wonderland by Lewis Carroll")
+        expect(item.description).to eq("Alice wonders in Wonderland\nIt's a classic children's book.")
+        expect(item.payment_method).to eq("PayPay PayPal")
       end
     end
 
-    context "when title_append is already joined" do
-      let(:item) { create(:item, :published, title: "Alice's Adventures in Wonderland by Lewis Carroll") }
+    context "when append contents are already joined" do
+      let(:item) { build(:item, :published, title: "Alice's Adventures in Wonderland by Lewis Carroll", description: "Alice wonders in Wonderland\nIt's a classic children's book.", payment_method: "PayPay PayPal") }
 
       it "does not joins twice" do
         item.title_append = "by Lewis Carroll"
-        item.send(:append_additional_contents)
+        item.description_append = "It's a classic children's book."
+        item.payment_method_append = "PayPal"
+        item.save!
+
         expect(item.title).to eq("Alice's Adventures in Wonderland by Lewis Carroll")
+        expect(item.description).to eq("Alice wonders in Wonderland\nIt's a classic children's book.")
+        expect(item.payment_method).to eq("PayPay PayPal")
       end
     end
   end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -192,6 +192,39 @@ RSpec.describe Item, type: :model do
     end
   end
 
+  describe "#combined_title_must_be_within_limit" do
+    let(:item) { build(:item, :published, title: "Alice's Adventures in Wonderland") }
+
+    it "validates title to be within limit" do
+      item.title_append = "a" * 250
+      item.send(:append_additional_contents)
+      expect(item.valid?(:publish)).to be false
+      expect(item.errors[:title]).to include("は合わせて255文字以内で入力してください")
+    end
+  end
+
+  describe "#combined_description_must_be_within_limit" do
+    let(:item) { build(:item, :published, description: "Alice wonders in Wonderland") }
+
+    it "validates title to be within limit" do
+      item.description_append = "a" * 999
+      item.send(:append_additional_contents)
+      expect(item.valid?(:publish)).to be false
+      expect(item.errors[:description]).to include("は合わせて1000文字以内で入力してください")
+    end
+  end
+
+  describe "#combined_payment_method_must_be_within_limit" do
+    let(:item) { build(:item, :published, payment_method: "PayPay") }
+
+    it "validates title to be within limit" do
+      item.payment_method_append = "a" * 250
+      item.send(:append_additional_contents)
+      expect(item.valid?(:publish)).to be false
+      expect(item.errors[:payment_method]).to include("は合わせて255文字以内で入力してください")
+    end
+  end
+
   describe "#deadline_must_be_today_or_later" do
     let(:item) { build(:item, :with_item_image, entry_deadline_at: entry_deadline_at) }
 
@@ -200,7 +233,7 @@ RSpec.describe Item, type: :model do
 
       it "validates deadline to not be earlier than today" do
         expect(item.valid?(:publish)).to be false
-        expect(item.errors[:entry_deadline_at]).to include ("は本日以降に設定してください")
+        expect(item.errors[:entry_deadline_at]).to include("は本日以降に設定してください")
       end
     end
 
@@ -273,6 +306,28 @@ RSpec.describe Item, type: :model do
         item.assign_attributes(entry_deadline_at: Date.current + 2.days)
 
         expect(item.valid?(:publish)).to be true
+      end
+    end
+  end
+
+  describe "#append_additional_contents" do
+    context "when title_append exists" do
+      let(:item) { create(:item, :published, title: "Alice's Adventures in Wonderland")}
+
+      it "adds to original title" do
+        item.title_append = "by Lewis Carroll"
+        item.send(:append_additional_contents)
+        expect(item.title).to eq("Alice's Adventures in Wonderland by Lewis Carroll")
+      end
+    end
+
+    context "when title_append is already joined" do
+      let(:item) { create(:item, :published, title: "Alice's Adventures in Wonderland by Lewis Carroll")}
+
+      it "does not joins twice" do
+        item.title_append = "by Lewis Carroll"
+        item.send(:append_additional_contents)
+        expect(item.title).to eq("Alice's Adventures in Wonderland by Lewis Carroll")
       end
     end
   end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -312,7 +312,7 @@ RSpec.describe Item, type: :model do
 
   describe "#append_additional_contents" do
     context "when title_append exists" do
-      let(:item) { create(:item, :published, title: "Alice's Adventures in Wonderland")}
+      let(:item) { create(:item, :published, title: "Alice's Adventures in Wonderland") }
 
       it "adds to original title" do
         item.title_append = "by Lewis Carroll"
@@ -322,7 +322,7 @@ RSpec.describe Item, type: :model do
     end
 
     context "when title_append is already joined" do
-      let(:item) { create(:item, :published, title: "Alice's Adventures in Wonderland by Lewis Carroll")}
+      let(:item) { create(:item, :published, title: "Alice's Adventures in Wonderland by Lewis Carroll") }
 
       it "does not joins twice" do
         item.title_append = "by Lewis Carroll"

--- a/spec/requests/items_spec.rb
+++ b/spec/requests/items_spec.rb
@@ -100,20 +100,20 @@ RSpec.describe "/items", type: :request do
     context "when item is not editable" do
       it "redirects to the item page" do
         item = create(:item, :sold, user: user, title: "技術書")
-        patch item_url(item), params: { item: { title_append: "初版" } }
+        patch item_url(item), params: { item: { title: "初版" } }
         expect(response).to redirect_to(item_url(item))
         expect(item.reload.title).to eq("技術書")
       end
     end
 
     context "when update as published with valid parameters" do
-      let(:new_attributes) { { title_append: "初版" } }
+      let(:new_attributes) { { title: "初版" } }
 
       it "updates the requested item" do
         item = create(:item, :published, :with_item_image, user: user, title: "技術書")
         patch item_url(item), params: { item: new_attributes, publish: true }
 
-        expect(item.reload.title).to eq("技術書 初版")
+        expect(item.reload.title).to eq("初版")
         expect(response).to redirect_to(item_url(item))
       end
     end
@@ -121,11 +121,11 @@ RSpec.describe "/items", type: :request do
     context "when update as published with invalid parameters" do
       let(:invalid_attributes) { { price: 1200 } }
 
-      it "renders a response with 422 status (i.e. to display the 'edit' template)" do
+      it "renders a response with 400 status)" do
         item = create(:item, :published, user: user, price: 1000)
         patch item_url(item), params: { item: invalid_attributes, publish: true }
 
-        expect(response).to have_http_status(:unprocessable_content)
+        expect(response).to have_http_status(:bad_request)
       end
     end
   end

--- a/spec/system/items_spec.rb
+++ b/spec/system/items_spec.rb
@@ -449,11 +449,11 @@ RSpec.describe "Items", type: :system do
         expect(page).to have_current_path(items_path)
         visit item_path(item)
         click_on '編集する'
-        fill_in '商品名の追記', with: '3冊'
+        fill_in '商品名', with: '技術書3冊セット'
         click_on '更新する'
 
         expect(page).to have_current_path(item_path(item))
-        expect(page).to have_content('技術書セット 3冊')
+        expect(page).to have_content('技術書3冊セット')
       end
     end
   end

--- a/spec/system/items_spec.rb
+++ b/spec/system/items_spec.rb
@@ -449,7 +449,7 @@ RSpec.describe "Items", type: :system do
         expect(page).to have_current_path(items_path)
         visit item_path(item)
         click_on '編集する'
-        fill_in "item[title_append]", with: '3冊'
+        fill_in '商品名の追記', with: '3冊'
         click_on '更新する'
 
         expect(page).to have_current_path(item_path(item))


### PR DESCRIPTION
## Issue
- #330 
## 概要
コントローラで行っていた追記内容を商品名等につなげる処理をモデルに移動させる修正を行った。その際下書きを更新してそのまま出品することができるようストロングパラメータの分岐を追加した。また、form_labelをtext_fieldと同期させ、日本語化はja.ymlで定義するよう変更した。