### PR TITLE
出品時の自動watch機能のメソッドを変更

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -11,7 +11,7 @@ class Comment < ApplicationRecord
   private
 
   def add_commenter_to_watchers
-    item.add_watcher(self.user)
+    item.add_watcher(user)
   end
 
   def notify_watchers

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -5,15 +5,13 @@ class Comment < ApplicationRecord
 
   validates :body, presence: true
 
-  after_create_commit :add_commentator_to_watchers
+  after_create_commit :add_commenter_to_watchers
   after_create_commit :notify_watchers
 
   private
 
-  def add_commentator_to_watchers
-    return if item.watchers.exists?(user_id)
-
-    item.watchers << self.user
+  def add_commenter_to_watchers
+    item.add_watcher(self.user)
   end
 
   def notify_watchers

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -40,8 +40,9 @@ class Item < ApplicationRecord
 
   before_save :set_entry_deadline_at_end_of_day, if: :will_save_change_to_entry_deadline_at?
 
-  after_save_commit :comment_watch_by_seller, if: -> { saved_change_to_attribute?(:status, to: "published") }
-  after_save_commit :notify_publishing, if: -> { saved_change_to_attribute?(:status, to: "published") }
+  after_save_commit :watch_on_publish, if: -> { saved_change_to_attribute?(:status, to: "published") }
+  after_save_commit :notify_publishing, if: -> { saved_change_to_attribute?(:status, to: "published" }
+
   after_update_commit :notify_deadline_extension, if: :saved_only_change_deadline?
 
   scope :not_expired, -> { where(entry_deadline_at: Time.current.beginning_of_day..) }
@@ -138,10 +139,10 @@ class Item < ApplicationRecord
     self.entry_deadline_at = entry_deadline_at.in_time_zone.end_of_day
   end
 
-  def comment_watch_by_seller
-    return if watchers.exists?(user.id)
-
-    watchers << user
+  def watch_on_publish
+    unless watchers.exists?(user.id)
+      watchers << user
+    end
   end
 
   def notify_publishing

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -108,6 +108,12 @@ class Item < ApplicationRecord
     entry_deadline_at.present? && entry_deadline_at < Time.current
   end
 
+  def add_watcher(user)
+    unless watchers.include?(user)
+      watchers << user
+    end
+  end
+
   private
 
   def deadline_must_be_today_or_later
@@ -140,9 +146,7 @@ class Item < ApplicationRecord
   end
 
   def watch_on_publish
-    unless watchers.exists?(user.id)
-      watchers << user
-    end
+    add_watcher(user)
   end
 
   def notify_publishing

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -41,7 +41,7 @@ class Item < ApplicationRecord
   before_save :set_entry_deadline_at_end_of_day, if: :will_save_change_to_entry_deadline_at?
 
   after_save_commit :watch_on_publish, if: -> { saved_change_to_attribute?(:status, to: "published") }
-  after_save_commit :notify_publishing, if: -> { saved_change_to_attribute?(:status, to: "published" }
+  after_save_commit :notify_publishing, if: -> { saved_change_to_attribute?(:status, to: "published") }
 
   after_update_commit :notify_deadline_extension, if: :saved_only_change_deadline?
 
@@ -89,6 +89,7 @@ class Item < ApplicationRecord
   def editable?
     return false if published? && expired?
     return false if sold?
+
     true
   end
 
@@ -108,10 +109,8 @@ class Item < ApplicationRecord
     entry_deadline_at.present? && entry_deadline_at < Time.current
   end
 
-  def add_watcher(user)
-    unless watchers.include?(user)
-      watchers << user
-    end
+  def add_watcher(target_user)
+    watchers << target_user unless watchers.include?(target_user)
   end
 
   private


### PR DESCRIPTION
## 概要
メソッド名を変更し、早期リターンを使わないよう修正した。また、watcherに追加する処理を共通化した。